### PR TITLE
Fix `CMD` hotkeys

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
     "name": "ogmoeditor",
+    "productName": "Ogmo",
     "version": "0.3.0",
     "description": "A general-case level editor for indie game developers!",
     "repository": "https://github.com/TheSpydog/OgmoEditor3-CE",

--- a/src/App.hx
+++ b/src/App.hx
@@ -55,12 +55,16 @@ class App
 				mainWindow.close();
 			});
 
+			IpcMain.on('updateMenu', (e) -> {
+				util.AppMenu.build();
+			});
+
 			mainWindow.on('closed', (e) -> {
 				mainWindow = null;
 			});
 		}
 
-		mainWindow.setMenu(null);
+		// mainWindow.setMenu(null);
 
 		// Compile in debug mode to load from webpack-dev-server and open dev tools on startup
 		#if debug

--- a/src/Ogmo.hx
+++ b/src/Ogmo.hx
@@ -12,6 +12,7 @@ import level.editor.ToolBelt;
 import util.Vector;
 import util.Keys;
 import util.Start;
+import util.AppMenu;
 
 class Ogmo
 {
@@ -102,10 +103,6 @@ class Ogmo
 				keyCheckMap[e.which] = false;
 				keyRelease(e.which);
 			}
-
-			// This fixes an issue with metakeys (Like CMD).
-			// While they are pressed, `keyup` events for other keys are not called.
-			if (e.which == Keys.Cmd) resetKeys();
 		});
 
 		new JQuery(Browser.window).on("mousemove", function (e:Event)
@@ -147,6 +144,14 @@ class Ogmo
 		if (editor.active) editor.loop();
 		if (projectEditor.active) projectEditor.loop();
 
+		// This fixes an issue with resetting keys while the CMD key is held on OSX.
+		// While CMD is pressed, `keyup` events for other keys are not called.
+		// So we need to manually reset them (excluding shift, alt, and CMD)
+		if (keyCheckMap[Keys.Cmd]) for (i in 0...keyCheckMap.length) 
+		{
+			if (i != Keys.Cmd && i != Keys.Shift && i != Keys.Alt && keyCheckMap[i] && !keyPressMap[i]) keyCheckMap[i] = false;
+		}
+
 		// Update the KeyPress Map
 		for (i in 0...keyPressMap.length) keyPressMap[i] = false;
 	}
@@ -185,6 +190,7 @@ class Ogmo
 		editor.setActive(false);
 		projectEditor.setActive(false);
 		startPage.setActive(true);
+		IpcRenderer.send('updateMenu', 'start');
 	}
 
 	public function gotoEditorPage():Void
@@ -192,6 +198,7 @@ class Ogmo
 		startPage.setActive(false);
 		projectEditor.setActive(false);
 		editor.setActive(true);
+		IpcRenderer.send('updateMenu', 'editor');
 	}
 
 	public function gotoProjectPage():Void
@@ -199,6 +206,7 @@ class Ogmo
 		startPage.setActive(false);
 		editor.setActive(false);
 		projectEditor.setActive(true);
+		IpcRenderer.send('updateMenu', 'project');
 	}
 
 	/*

--- a/src/util/AppMenu.hx
+++ b/src/util/AppMenu.hx
@@ -1,0 +1,65 @@
+package util;
+
+import js.Node.process;
+
+typedef MenuTemplate = 
+{
+  ?label:String,
+  ?role:String,
+  ?type:String,
+  ?submenu:Array<MenuTemplate>
+}
+
+class AppMenu 
+{
+  public static function build() 
+  {
+    var template:Array<MenuTemplate> = [];
+    
+    if (process.platform == 'darwin') template.push({
+      label: 'Ogmo',
+      submenu: [
+        { role: 'about' },
+        { type: 'separator' },
+        { role: 'services' },
+        { type: 'separator' },
+        { role: 'hide' },
+        { role: 'hideothers' },
+        { role: 'unhide' },
+        { type: 'separator' },
+        { role: 'quit' }
+      ]
+    });
+
+    // TODO - add menu items based on the current app state
+    // if (Ogmo.startPage.active)
+    // {
+      
+    // }
+
+    // if (Ogmo.editor.active)
+    // {
+      
+    // }
+
+    // if (Ogmo.projectEditor.active)
+    // {
+      
+    // }
+
+    #if debug
+    template.push({
+      label: 'Develop',
+      submenu: [
+        { role: 'reload' },
+        { role: 'forcereload' },
+        { role: 'toggledevtools' },
+      ]
+    });
+    #end
+
+    var menu = electron.main.Menu.buildFromTemplate(template);
+    electron.main.Menu.setApplicationMenu(menu);
+    // OGMO.app.setMenu(template);
+  }
+}


### PR DESCRIPTION
closes #42. This fixes the issue with jquery not receiving `keyup` events for any keys while `CMD` is held down. 

This PR also has some Application Menu work in there - its from an early attempt to fix this issue through registering the hotkeys through the Application Menu. Even though that ended up not being the solution to this issue, I left it in as it can provide the basis for issue #17.