### PR TITLE
lixify

### DIFF
--- a/.haxerc
+++ b/.haxerc
@@ -1,0 +1,4 @@
+{
+  "version": "4.0.2",
+  "resolveLibs": "scoped"
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+    "recommendations": [
+        "nadako.vshaxe",
+        "lix.lix"
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -6,20 +6,10 @@
 
 # Getting Started
 
-This project requires Haxe v4.0.0 or later, Node v10+, and various dependencies for each of them.
+This project requires Node v10+, and will install various other dependencies automatically, including the haxe compiler.
 
 ### Node
 * Install [Node](https://nodejs.org/)
-
-### Haxe
-* Install [Haxe](https://haxe.org/download/)
-* Run the following commands:
-```
-haxelib setup
-haxelib install electron 4.1.4
-haxelib install jQueryExtern
-haxelib install haxe-loader
-```
 
 ## Build
 ```
@@ -33,7 +23,7 @@ Speed up development by using Webpack's dev server! Running `npm run dev` builds
 
 While running the dev server, all code that is within `#if debug` conditionals are added in.
 
-NOTES: 
+NOTES:
   * Changes to `App.hx` are not watched, and the app will need to manually be rebuilt if changes are made there.
   * The app will need to be rebuilt normally (`npm run build`) in order to run it again after using the dev server.
 

--- a/haxe_libraries/electron.hxml
+++ b/haxe_libraries/electron.hxml
@@ -1,0 +1,4 @@
+-D electron=4.1.4
+# @install: lix --silent download "haxelib:/electron#4.1.4" into electron/4.1.4/haxelib
+-lib hxnodejs
+-cp ${HAXE_LIBCACHE}/electron/4.1.4/haxelib/src

--- a/haxe_libraries/haxe-loader.hxml
+++ b/haxe_libraries/haxe-loader.hxml
@@ -1,0 +1,3 @@
+-D haxe-loader=0.9.0
+# @install: lix --silent download "haxelib:/haxe-loader#0.9.0" into haxe-loader/0.9.0/haxelib
+-cp ${HAXE_LIBCACHE}/haxe-loader/0.9.0/haxelib/haxelib/

--- a/haxe_libraries/hxnodejs.hxml
+++ b/haxe_libraries/hxnodejs.hxml
@@ -1,0 +1,6 @@
+-D hxnodejs=10.0.0
+# @install: lix --silent download "haxelib:/hxnodejs#10.0.0" into hxnodejs/10.0.0/haxelib
+-cp ${HAXE_LIBCACHE}/hxnodejs/10.0.0/haxelib/src
+--macro allowPackage('sys')
+# should behave like other target defines and not be defined in macro context
+--macro define('nodejs')

--- a/haxe_libraries/jQueryExtern.hxml
+++ b/haxe_libraries/jQueryExtern.hxml
@@ -1,0 +1,4 @@
+-D jQueryExtern=3.2.1
+# @install: lix --silent download "haxelib:/jQueryExtern#3.2.1" into jQueryExtern/3.2.1/haxelib
+-cp ${HAXE_LIBCACHE}/jQueryExtern/3.2.1/haxelib/
+--macro js.jquery.Config.init()

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "ogmoeditor",
-    "version": "3.0.0",
+    "version": "3.1.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -4809,6 +4809,12 @@
                 "invert-kv": "^1.0.0"
             }
         },
+        "lix": {
+            "version": "15.6.0-alpha.1",
+            "resolved": "https://registry.npmjs.org/lix/-/lix-15.6.0-alpha.1.tgz",
+            "integrity": "sha512-lEU2T10Qp/l0kis11QKiMxfVcqh6PSIm4leOv7Hg/xdcAi427iPBKoo4jChLdmQkzr4LY2LHQgeLSXEcH38Edg==",
+            "dev": true
+        },
         "load-bmfont": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/load-bmfont/-/load-bmfont-1.4.0.tgz",
@@ -8597,7 +8603,8 @@
                         "ansi-regex": {
                             "version": "2.1.1",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         },
                         "aproba": {
                             "version": "1.2.0",
@@ -8618,12 +8625,14 @@
                         "balanced-match": {
                             "version": "1.0.0",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         },
                         "brace-expansion": {
                             "version": "1.1.11",
                             "bundled": true,
                             "dev": true,
+                            "optional": true,
                             "requires": {
                                 "balanced-match": "^1.0.0",
                                 "concat-map": "0.0.1"
@@ -8638,17 +8647,20 @@
                         "code-point-at": {
                             "version": "1.1.0",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         },
                         "concat-map": {
                             "version": "0.0.1",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         },
                         "console-control-strings": {
                             "version": "1.1.0",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         },
                         "core-util-is": {
                             "version": "1.0.2",
@@ -8765,7 +8777,8 @@
                         "inherits": {
                             "version": "2.0.3",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         },
                         "ini": {
                             "version": "1.3.5",
@@ -8777,6 +8790,7 @@
                             "version": "1.0.0",
                             "bundled": true,
                             "dev": true,
+                            "optional": true,
                             "requires": {
                                 "number-is-nan": "^1.0.0"
                             }
@@ -8791,6 +8805,7 @@
                             "version": "3.0.4",
                             "bundled": true,
                             "dev": true,
+                            "optional": true,
                             "requires": {
                                 "brace-expansion": "^1.1.7"
                             }
@@ -8798,12 +8813,14 @@
                         "minimist": {
                             "version": "0.0.8",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         },
                         "minipass": {
                             "version": "2.3.5",
                             "bundled": true,
                             "dev": true,
+                            "optional": true,
                             "requires": {
                                 "safe-buffer": "^5.1.2",
                                 "yallist": "^3.0.0"
@@ -8822,6 +8839,7 @@
                             "version": "0.5.1",
                             "bundled": true,
                             "dev": true,
+                            "optional": true,
                             "requires": {
                                 "minimist": "0.0.8"
                             }
@@ -8902,7 +8920,8 @@
                         "number-is-nan": {
                             "version": "1.0.1",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         },
                         "object-assign": {
                             "version": "4.1.1",
@@ -8914,6 +8933,7 @@
                             "version": "1.4.0",
                             "bundled": true,
                             "dev": true,
+                            "optional": true,
                             "requires": {
                                 "wrappy": "1"
                             }
@@ -8999,7 +9019,8 @@
                         "safe-buffer": {
                             "version": "5.1.2",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         },
                         "safer-buffer": {
                             "version": "2.1.2",
@@ -9035,6 +9056,7 @@
                             "version": "1.0.2",
                             "bundled": true,
                             "dev": true,
+                            "optional": true,
                             "requires": {
                                 "code-point-at": "^1.0.0",
                                 "is-fullwidth-code-point": "^1.0.0",
@@ -9054,6 +9076,7 @@
                             "version": "3.0.1",
                             "bundled": true,
                             "dev": true,
+                            "optional": true,
                             "requires": {
                                 "ansi-regex": "^2.0.0"
                             }
@@ -9097,12 +9120,14 @@
                         "wrappy": {
                             "version": "1.0.2",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         },
                         "yallist": {
                             "version": "3.0.3",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         }
                     }
                 },
@@ -9558,7 +9583,8 @@
                         "ansi-regex": {
                             "version": "2.1.1",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         },
                         "aproba": {
                             "version": "1.2.0",
@@ -9579,12 +9605,14 @@
                         "balanced-match": {
                             "version": "1.0.0",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         },
                         "brace-expansion": {
                             "version": "1.1.11",
                             "bundled": true,
                             "dev": true,
+                            "optional": true,
                             "requires": {
                                 "balanced-match": "^1.0.0",
                                 "concat-map": "0.0.1"
@@ -9599,17 +9627,20 @@
                         "code-point-at": {
                             "version": "1.1.0",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         },
                         "concat-map": {
                             "version": "0.0.1",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         },
                         "console-control-strings": {
                             "version": "1.1.0",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         },
                         "core-util-is": {
                             "version": "1.0.2",
@@ -9726,7 +9757,8 @@
                         "inherits": {
                             "version": "2.0.3",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         },
                         "ini": {
                             "version": "1.3.5",
@@ -9738,6 +9770,7 @@
                             "version": "1.0.0",
                             "bundled": true,
                             "dev": true,
+                            "optional": true,
                             "requires": {
                                 "number-is-nan": "^1.0.0"
                             }
@@ -9752,6 +9785,7 @@
                             "version": "3.0.4",
                             "bundled": true,
                             "dev": true,
+                            "optional": true,
                             "requires": {
                                 "brace-expansion": "^1.1.7"
                             }
@@ -9759,12 +9793,14 @@
                         "minimist": {
                             "version": "0.0.8",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         },
                         "minipass": {
                             "version": "2.3.5",
                             "bundled": true,
                             "dev": true,
+                            "optional": true,
                             "requires": {
                                 "safe-buffer": "^5.1.2",
                                 "yallist": "^3.0.0"
@@ -9783,6 +9819,7 @@
                             "version": "0.5.1",
                             "bundled": true,
                             "dev": true,
+                            "optional": true,
                             "requires": {
                                 "minimist": "0.0.8"
                             }
@@ -9863,7 +9900,8 @@
                         "number-is-nan": {
                             "version": "1.0.1",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         },
                         "object-assign": {
                             "version": "4.1.1",
@@ -9875,6 +9913,7 @@
                             "version": "1.4.0",
                             "bundled": true,
                             "dev": true,
+                            "optional": true,
                             "requires": {
                                 "wrappy": "1"
                             }
@@ -9960,7 +9999,8 @@
                         "safe-buffer": {
                             "version": "5.1.2",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         },
                         "safer-buffer": {
                             "version": "2.1.2",
@@ -9996,6 +10036,7 @@
                             "version": "1.0.2",
                             "bundled": true,
                             "dev": true,
+                            "optional": true,
                             "requires": {
                                 "code-point-at": "^1.0.0",
                                 "is-fullwidth-code-point": "^1.0.0",
@@ -10015,6 +10056,7 @@
                             "version": "3.0.1",
                             "bundled": true,
                             "dev": true,
+                            "optional": true,
                             "requires": {
                                 "ansi-regex": "^2.0.0"
                             }
@@ -10058,12 +10100,14 @@
                         "wrappy": {
                             "version": "1.0.2",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         },
                         "yallist": {
                             "version": "3.0.3",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         }
                     }
                 },

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
         "electron-icon-maker": "0.0.4",
         "file-loader": "^3.0.1",
         "haxe-loader": "^0.10.0",
+        "lix": "^15.6.0-alpha.1",
         "node-loader": "^0.6.0",
         "node-sass": "^4.12.0",
         "sass-loader": "^7.1.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
         "build": "webpack --config=webpack.app.config.js --mode=production && webpack --config=webpack.ogmo.config.js --mode=production",
         "dev": "webpack --config=webpack.app.config.js --mode=development && webpack-dev-server --config=webpack.ogmo.config.js --mode=development --host 0.0.0.0",
         "icons": "electron-icon-maker --input=./assets/gfx/icon.png --output=./assets/build",
-        "dist": "electron-builder --config electron-builder.json"
+        "dist": "electron-builder --config electron-builder.json",
+        "postinstall": "npx lix download"
     },
     "devDependencies": {
         "clean-webpack-plugin": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
         "dev": "webpack --config=webpack.app.config.js --mode=development && webpack-dev-server --config=webpack.ogmo.config.js --mode=development --host 0.0.0.0",
         "icons": "electron-icon-maker --input=./assets/gfx/icon.png --output=./assets/build",
         "dist": "electron-builder --config electron-builder.json",
-        "postinstall": "npx lix download"
+        "postinstall": "lix download"
     },
     "devDependencies": {
         "clean-webpack-plugin": "^2.0.1",


### PR DESCRIPTION
Not sure if you think this is useful, but this PR adds support for [lix](https://github.com/lix-pm/lix.client), so you don't need a globally installed haxe/haxelib anymore.