### PR TITLE
export correct value types

### DIFF
--- a/src/level/data/Value.hx
+++ b/src/level/data/Value.hx
@@ -5,16 +5,16 @@ import project.data.value.ValueTemplate;
 class Value
 {
 	public var template:ValueTemplate;
-	public var value:String;
+	public var value:Dynamic;
 
-	public function new(template:ValueTemplate, ?value:String)
+	public function new(template:ValueTemplate, ?value:Dynamic)
 	{
 		this.template = template;
 		if (value == null) this.value = this.template.getDefault();
 		else this.value = this.template.validate(value);
 	}
 
-	public function set(value:String):Void
+	public function set(value:Dynamic):Void
 	{
 		this.value = template.validate(value);
 	}

--- a/src/project/data/value/BoolValueTemplate.hx
+++ b/src/project/data/value/BoolValueTemplate.hx
@@ -26,9 +26,11 @@ class BoolValueTemplate extends ValueTemplate
     return Std.string(defaults);
   }
 
-  override function validate(val:String):String
+  override function validate(val:Dynamic):Bool
   {
-    return Std.string(Imports.bool(val, defaults));
+    //return Std.string(Imports.bool(val, defaults));
+    if (val.is(String)) return val == 'true';
+    return val.is(Bool) ? val : false;
   }
 
   override function createEditor(values:Array<Value>):ValueEditor

--- a/src/project/data/value/ColorValueTemplate.hx
+++ b/src/project/data/value/ColorValueTemplate.hx
@@ -26,10 +26,10 @@ class ColorValueTemplate extends ValueTemplate
     return defaults.toHexAlpha();
   }
 
-  override function validate(val:String):String
+  override function validate(val:Dynamic):Int
   {
     //TODO!!
-    return val;
+    return cast val;
   }
 
   override function createEditor(values:Array<Value>):Null<ColorValueEditor>

--- a/src/project/data/value/EnumValueTemplate.hx
+++ b/src/project/data/value/EnumValueTemplate.hx
@@ -28,8 +28,9 @@ class EnumValueTemplate extends ValueTemplate
     return "";
   }
 
-  override function validate(val:String):String 
+  override function validate(val:Dynamic):String 
   {
+    val = val.string();
     if (choices.length > 0)
     {
       var n = choices.indexOf(val);

--- a/src/project/data/value/FloatValueTemplate.hx
+++ b/src/project/data/value/FloatValueTemplate.hx
@@ -28,14 +28,14 @@ class FloatValueTemplate extends ValueTemplate
         return '$defaults';
     }
 
-    override function validate(val: String): String
+    override function validate(val:Dynamic):Float
     {
         var number = Imports.float(val, defaults);
         if (bounded && number < min)
             number = min;
         else if (bounded && number > max)
             number = max;
-        return '$number';
+        return number;
     }
 
     override function createEditor(values:Array<Value>):ValueEditor

--- a/src/project/data/value/IntegerValueTemplate.hx
+++ b/src/project/data/value/IntegerValueTemplate.hx
@@ -29,14 +29,14 @@ class IntegerValueTemplate extends ValueTemplate
         return Std.string(defaults);
     }
 
-    override function validate(val:String):String
+    override function validate(val:Dynamic):Int
     {
         var number = Imports.integer(val, defaults);
         if (bounded && number < min)
             number = min
         else if (bounded && number > max)
             number = max;
-        return  Std.string(number);
+        return  number;
     }
 
     override function createEditor(values:Array<Value>):ValueEditor

--- a/src/project/data/value/StringValueTemplate.hx
+++ b/src/project/data/value/StringValueTemplate.hx
@@ -27,10 +27,10 @@ class StringValueTemplate extends ValueTemplate
     return defaults;
   }
 
-  override function validate(val:String):String
+  override function validate(val:Dynamic):String
   {
     //TODO!!
-    return val;
+    return val.string();
   }
 
   override function createEditor(values:Array<Value>):ValueEditor

--- a/src/project/data/value/TextValueTemplate.hx
+++ b/src/project/data/value/TextValueTemplate.hx
@@ -25,10 +25,10 @@ class TextValueTemplate extends ValueTemplate
     return defaults;
   }
 
-  override function validate(val:String):String
+  override function validate(val:Dynamic):String
   {
     //TODO!!
-    return val;
+    return val.string();
   }
 
   override function createEditor(values:Array<Value>): ValueEditor

--- a/src/project/data/value/ValueTemplate.hx
+++ b/src/project/data/value/ValueTemplate.hx
@@ -37,7 +37,7 @@ class ValueTemplate
   }
 
   public function getDefault():String return '';
-  public function validate(val:String):String return '';
+  public function validate(val:Dynamic):Dynamic return '';
   public function createEditor(values:Array<Value>):Null<ValueEditor> return null;
   public function getHashCode():String return '';
   public function load(val:Dynamic):Void {}


### PR DESCRIPTION
This fixes #65 by using the correct types on exported value fields

example:
```
"values": {"bool": true, "color": "#8d00ffff", "enum": "one", "float": 10, "int": 9, "string": "hello", "text": "hello\nworld"}
```