### PR TITLE
fix the ogmo editor process running after closing all windows

### DIFF
--- a/src/App.hx
+++ b/src/App.hx
@@ -15,7 +15,7 @@ class App
 
   static function main()
 	{
-		ElectronApp.on('window_all_closed', (e) -> {
+		ElectronApp.on('window-all-closed', (e) -> {
 			if (process.platform != 'darwin') ElectronApp.quit();
 			process.exit(0);
 		});


### PR DESCRIPTION
I noticed that when running Ogmo from the Itch app, the "launch" button would still say "running" after closing the window. I can see the Ogmo processes in the task manager just hanging around. Interestingly, this only seems to happen when running the exe generated by electron-builder. I believe this should fix the issue.