### PR TITLE
Normalize exported Filepaths

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8597,7 +8597,8 @@
                         "ansi-regex": {
                             "version": "2.1.1",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         },
                         "aproba": {
                             "version": "1.2.0",
@@ -8618,12 +8619,14 @@
                         "balanced-match": {
                             "version": "1.0.0",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         },
                         "brace-expansion": {
                             "version": "1.1.11",
                             "bundled": true,
                             "dev": true,
+                            "optional": true,
                             "requires": {
                                 "balanced-match": "^1.0.0",
                                 "concat-map": "0.0.1"
@@ -8638,17 +8641,20 @@
                         "code-point-at": {
                             "version": "1.1.0",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         },
                         "concat-map": {
                             "version": "0.0.1",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         },
                         "console-control-strings": {
                             "version": "1.1.0",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         },
                         "core-util-is": {
                             "version": "1.0.2",
@@ -8765,7 +8771,8 @@
                         "inherits": {
                             "version": "2.0.3",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         },
                         "ini": {
                             "version": "1.3.5",
@@ -8777,6 +8784,7 @@
                             "version": "1.0.0",
                             "bundled": true,
                             "dev": true,
+                            "optional": true,
                             "requires": {
                                 "number-is-nan": "^1.0.0"
                             }
@@ -8791,6 +8799,7 @@
                             "version": "3.0.4",
                             "bundled": true,
                             "dev": true,
+                            "optional": true,
                             "requires": {
                                 "brace-expansion": "^1.1.7"
                             }
@@ -8798,12 +8807,14 @@
                         "minimist": {
                             "version": "0.0.8",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         },
                         "minipass": {
                             "version": "2.3.5",
                             "bundled": true,
                             "dev": true,
+                            "optional": true,
                             "requires": {
                                 "safe-buffer": "^5.1.2",
                                 "yallist": "^3.0.0"
@@ -8822,6 +8833,7 @@
                             "version": "0.5.1",
                             "bundled": true,
                             "dev": true,
+                            "optional": true,
                             "requires": {
                                 "minimist": "0.0.8"
                             }
@@ -8902,7 +8914,8 @@
                         "number-is-nan": {
                             "version": "1.0.1",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         },
                         "object-assign": {
                             "version": "4.1.1",
@@ -8914,6 +8927,7 @@
                             "version": "1.4.0",
                             "bundled": true,
                             "dev": true,
+                            "optional": true,
                             "requires": {
                                 "wrappy": "1"
                             }
@@ -8999,7 +9013,8 @@
                         "safe-buffer": {
                             "version": "5.1.2",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         },
                         "safer-buffer": {
                             "version": "2.1.2",
@@ -9035,6 +9050,7 @@
                             "version": "1.0.2",
                             "bundled": true,
                             "dev": true,
+                            "optional": true,
                             "requires": {
                                 "code-point-at": "^1.0.0",
                                 "is-fullwidth-code-point": "^1.0.0",
@@ -9054,6 +9070,7 @@
                             "version": "3.0.1",
                             "bundled": true,
                             "dev": true,
+                            "optional": true,
                             "requires": {
                                 "ansi-regex": "^2.0.0"
                             }
@@ -9097,12 +9114,14 @@
                         "wrappy": {
                             "version": "1.0.2",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         },
                         "yallist": {
                             "version": "3.0.3",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         }
                     }
                 },
@@ -9558,7 +9577,8 @@
                         "ansi-regex": {
                             "version": "2.1.1",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         },
                         "aproba": {
                             "version": "1.2.0",
@@ -9579,12 +9599,14 @@
                         "balanced-match": {
                             "version": "1.0.0",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         },
                         "brace-expansion": {
                             "version": "1.1.11",
                             "bundled": true,
                             "dev": true,
+                            "optional": true,
                             "requires": {
                                 "balanced-match": "^1.0.0",
                                 "concat-map": "0.0.1"
@@ -9599,17 +9621,20 @@
                         "code-point-at": {
                             "version": "1.1.0",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         },
                         "concat-map": {
                             "version": "0.0.1",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         },
                         "console-control-strings": {
                             "version": "1.1.0",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         },
                         "core-util-is": {
                             "version": "1.0.2",
@@ -9726,7 +9751,8 @@
                         "inherits": {
                             "version": "2.0.3",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         },
                         "ini": {
                             "version": "1.3.5",
@@ -9738,6 +9764,7 @@
                             "version": "1.0.0",
                             "bundled": true,
                             "dev": true,
+                            "optional": true,
                             "requires": {
                                 "number-is-nan": "^1.0.0"
                             }
@@ -9752,6 +9779,7 @@
                             "version": "3.0.4",
                             "bundled": true,
                             "dev": true,
+                            "optional": true,
                             "requires": {
                                 "brace-expansion": "^1.1.7"
                             }
@@ -9759,12 +9787,14 @@
                         "minimist": {
                             "version": "0.0.8",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         },
                         "minipass": {
                             "version": "2.3.5",
                             "bundled": true,
                             "dev": true,
+                            "optional": true,
                             "requires": {
                                 "safe-buffer": "^5.1.2",
                                 "yallist": "^3.0.0"
@@ -9783,6 +9813,7 @@
                             "version": "0.5.1",
                             "bundled": true,
                             "dev": true,
+                            "optional": true,
                             "requires": {
                                 "minimist": "0.0.8"
                             }
@@ -9863,7 +9894,8 @@
                         "number-is-nan": {
                             "version": "1.0.1",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         },
                         "object-assign": {
                             "version": "4.1.1",
@@ -9875,6 +9907,7 @@
                             "version": "1.4.0",
                             "bundled": true,
                             "dev": true,
+                            "optional": true,
                             "requires": {
                                 "wrappy": "1"
                             }
@@ -9960,7 +9993,8 @@
                         "safe-buffer": {
                             "version": "5.1.2",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         },
                         "safer-buffer": {
                             "version": "2.1.2",
@@ -9996,6 +10030,7 @@
                             "version": "1.0.2",
                             "bundled": true,
                             "dev": true,
+                            "optional": true,
                             "requires": {
                                 "code-point-at": "^1.0.0",
                                 "is-fullwidth-code-point": "^1.0.0",
@@ -10015,6 +10050,7 @@
                             "version": "3.0.1",
                             "bundled": true,
                             "dev": true,
+                            "optional": true,
                             "requires": {
                                 "ansi-regex": "^2.0.0"
                             }
@@ -10058,12 +10094,14 @@
                         "wrappy": {
                             "version": "1.0.2",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         },
                         "yallist": {
                             "version": "3.0.3",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         }
                     }
                 },

--- a/src/modules/decals/Decal.hx
+++ b/src/modules/decals/Decal.hx
@@ -1,6 +1,7 @@
 package modules.decals;
 
 import rendering.Texture;
+import js.node.Path;
 
 class Decal
 {
@@ -35,7 +36,7 @@ class Decal
 			data.scaleY = scale.y;
 		}
 		if (rotatable) data.rotation = rotation;
-		data.texture = path;
+		data.texture = Path.posix.normalize(path);
 		return data;
 	}
 

--- a/src/modules/decals/Decal.hx
+++ b/src/modules/decals/Decal.hx
@@ -1,7 +1,6 @@
 package modules.decals;
 
 import rendering.Texture;
-import haxe.io.Path;
 
 class Decal
 {
@@ -36,7 +35,7 @@ class Decal
 			data.scaleY = scale.y;
 		}
 		if (rotatable) data.rotation = rotation;
-		data.texture = Path.normalize(path);
+		data.texture = haxe.io.Path.normalize(path);
 		return data;
 	}
 

--- a/src/modules/decals/Decal.hx
+++ b/src/modules/decals/Decal.hx
@@ -1,7 +1,7 @@
 package modules.decals;
 
 import rendering.Texture;
-import js.node.Path;
+import haxe.io.Path;
 
 class Decal
 {
@@ -36,7 +36,7 @@ class Decal
 			data.scaleY = scale.y;
 		}
 		if (rotatable) data.rotation = rotation;
-		data.texture = Path.posix.normalize(path);
+		data.texture = Path.normalize(path);
 		return data;
 	}
 

--- a/src/modules/decals/DecalLayer.hx
+++ b/src/modules/decals/DecalLayer.hx
@@ -29,7 +29,7 @@ class DecalLayer extends Layer
       for (decal in decals)
       {
         var position = Imports.vector(decal, "x", "y");
-        var path = Path.normalize(decal.texture);
+        var path = Path.posix.normalize(decal.texture);
         var relative = Path.join((cast template : DecalLayerTemplate).folder, path);
         var texture:Texture = null;
         var scale = Imports.vector(decal, "scaleX", "scaleY", new Vector(1, 1));

--- a/src/modules/decals/DecalLayer.hx
+++ b/src/modules/decals/DecalLayer.hx
@@ -29,7 +29,7 @@ class DecalLayer extends Layer
       for (decal in decals)
       {
         var position = Imports.vector(decal, "x", "y");
-        var path = Path.posix.normalize(decal.texture);
+        var path = haxe.io.Path.normalize(decal.texture);
         var relative = Path.join((cast template : DecalLayerTemplate).folder, path);
         var texture:Texture = null;
         var scale = Imports.vector(decal, "scaleX", "scaleY", new Vector(1, 1));

--- a/src/modules/entities/EntityTemplate.hx
+++ b/src/modules/entities/EntityTemplate.hx
@@ -98,7 +98,7 @@ class EntityTemplate
 		return next;
 	}
 
-	public static function load(data:Dynamic):EntityTemplate
+	public static function load(project:Project, data:Dynamic):EntityTemplate
 	{
 		var e = new EntityTemplate();
 
@@ -131,8 +131,7 @@ class EntityTemplate
 		if (data.texture != null)
 		{
 			 if (FileSystem.exists(data.texture)) e.texture = Texture.fromFile(data.texture);
-			 else if (FileSystem.exists(Path.join(Path.dirname(OGMO.project.path), data.texture))) e.texture = Texture.fromFile(Path.join(Path.dirname(OGMO.project.path), data.texture));
-			 
+			 else if (FileSystem.exists(Path.join(Path.dirname(project.path), data.texture))) e.texture = Texture.fromFile(Path.join(Path.dirname(project.path), data.texture));
 		}
 		// If that didnt work, try to load the base64'd version
 		if (e.texture == null && data.textureImage != null) e.texture = Texture.fromString(data.textureImage);

--- a/src/modules/entities/EntityTemplate.hx
+++ b/src/modules/entities/EntityTemplate.hx
@@ -170,7 +170,7 @@ class EntityTemplate
 
 		if (texture != null) 
 		{
-			e.texture = Path.relative(Path.dirname(OGMO.project.path), texture.path);
+			e.texture = Path.posix.normalize(Path.relative(Path.dirname(OGMO.project.path), texture.path));
 			e.textureImage = texture.image.src;
 		}
 

--- a/src/modules/entities/EntityTemplate.hx
+++ b/src/modules/entities/EntityTemplate.hx
@@ -170,7 +170,7 @@ class EntityTemplate
 
 		if (texture != null) 
 		{
-			e.texture = Path.posix.normalize(Path.relative(Path.dirname(OGMO.project.path), texture.path));
+			e.texture = haxe.io.Path.normalize(Path.relative(Path.dirname(OGMO.project.path), texture.path));
 			e.textureImage = texture.image.src;
 		}
 

--- a/src/modules/entities/ProjectEntitiesPanel.hx
+++ b/src/modules/entities/ProjectEntitiesPanel.hx
@@ -632,7 +632,7 @@ class ProjectEntitiesPanel extends ProjectEditorPanel
 			for (entity in (cast data.entities : Array<EntityTemplate>)) 
 			{
 				if (OGMO.project.entities.templates.filter(e -> e.exportID == entity.exportID).length == 0) {
-					OGMO.project.entities.templates.push(EntityTemplate.load(entity));
+					OGMO.project.entities.templates.push(EntityTemplate.load(OGMO.project, entity));
 					addedCount++;
 				}
 				else notAddedCount++;

--- a/src/project/data/Project.hx
+++ b/src/project/data/Project.hx
@@ -167,7 +167,7 @@ class Project
 		//Entity Templates
 		if (data.entityTags != null) for (tag in data.entityTags) entities.tags.push(tag);
 		
-		for (entity in data.entities) entities.templates.push(EntityTemplate.load(entity));
+		for (entity in data.entities) entities.templates.push(EntityTemplate.load(this, entity));
 		entities.refreshTagLists();
 
 		initLastSavePath();

--- a/src/project/data/Project.hx
+++ b/src/project/data/Project.hx
@@ -40,7 +40,7 @@ class Project
 	public function new(path:String)
 	{
 		this.name = "New Project";
-		this.path = Path.resolve(path);
+		this.path = Path.resolve(Path.normalize(path));
 	}
 	
 	public function unload()

--- a/src/project/data/Tileset.hx
+++ b/src/project/data/Tileset.hx
@@ -28,7 +28,7 @@ class Tileset
   public function new(project:Project, label:String, path:String, tileWidth:Int, tileHeight:Int, tileSepX:Int, tileSepY:Int, ?image:ImageElement)
   {
     this.label = label;
-    this.path = Path.normalize(path);
+    this.path = haxe.io.Path.normalize(path);
     this.tileWidth = tileWidth;
     this.tileHeight = tileHeight;
     this.tileSeparationX = tileSepX;

--- a/src/project/data/Tileset.hx
+++ b/src/project/data/Tileset.hx
@@ -28,7 +28,7 @@ class Tileset
   public function new(project:Project, label:String, path:String, tileWidth:Int, tileHeight:Int, tileSepX:Int, tileSepY:Int, ?image:ImageElement)
   {
     this.label = label;
-    this.path = path;
+    this.path = Path.normalize(path);
     this.tileWidth = tileWidth;
     this.tileHeight = tileHeight;
     this.tileSeparationX = tileSepX;

--- a/src/rendering/Texture.hx
+++ b/src/rendering/Texture.hx
@@ -3,7 +3,7 @@ package rendering;
 import js.html.webgl.RenderingContext;
 import js.Browser;
 import js.html.ImageElement;
-import js.node.Path;
+import haxe.io.Path;
 import io.FileSystem;
 import util.Vector;
 

--- a/src/rendering/Texture.hx
+++ b/src/rendering/Texture.hx
@@ -3,7 +3,6 @@ package rendering;
 import js.html.webgl.RenderingContext;
 import js.Browser;
 import js.html.ImageElement;
-import haxe.io.Path;
 import io.FileSystem;
 import util.Vector;
 
@@ -24,12 +23,13 @@ class Texture
 	public static function fromString(data: String): Texture
 	{
 		var image = Browser.document.createImageElement();
-		image.src = Path.normalize(data);   
+		image.src = haxe.io.Path.normalize(data);   
 		return new Texture(image);
 	}
 	
 	public static function fromFile(path: String): Texture
 	{
+		path = haxe.io.Path.normalize(path);
 		var img = FileSystem.loadImage(path);
 		if (img != null)
 		{

--- a/src/rendering/Texture.hx
+++ b/src/rendering/Texture.hx
@@ -3,6 +3,7 @@ package rendering;
 import js.html.webgl.RenderingContext;
 import js.Browser;
 import js.html.ImageElement;
+import js.node.Path;
 import io.FileSystem;
 import util.Vector;
 
@@ -23,7 +24,7 @@ class Texture
 	public static function fromString(data: String): Texture
 	{
 		var image = Browser.document.createImageElement();
-		image.src = data;   
+		image.src = Path.normalize(data);   
 		return new Texture(image);
 	}
 	


### PR DESCRIPTION
closes #89 

This normalizes all exported filepaths (that i know of) to `"look/like/this"`. This'll also "auto-upgrade" projects that have different filepath styles `"like\\this"`, so no worries about breaking changes :)