### PR TITLE
Gray irrelevant options in toolbar, fix #73

### DIFF
--- a/src/assets/styles/editor.scss
+++ b/src/assets/styles/editor.scss
@@ -442,8 +442,14 @@
         }
 		.tool:after { transition: background-color 0.25s; }
         .tool:last-child { border-right: 0; border-radius: 0 0 4px 0; }
-
+        
         .tool:hover  { background: #fff; }
+        .tool.unavailable { 
+            background: #444 !important;
+            border-right: 1px solid #222;
+            cursor: not-allowed;
+            transition-duration: 0ms;
+        }
         .tool.selected { background: #fff; }
 		.tool.selected:after { background-color: #ff0044; }
         .tool.key-selected { background: #fff; }

--- a/src/level/editor/Editor.hx
+++ b/src/level/editor/Editor.hx
@@ -523,6 +523,9 @@ class Editor
 
 		//Current Tool
 		if (EDITOR.toolBelt.current != null) EDITOR.toolBelt.current.draw();
+
+		//Check Tools availability
+		EDITOR.toolBelt.checkAvailability();
 		
 		draw.finishDrawing();
 	}

--- a/src/level/editor/Tool.hx
+++ b/src/level/editor/Tool.hx
@@ -29,4 +29,5 @@ class Tool
 	public function keyToolShift():Int return -1;
 	public function keyToolCtrl():Int return -1;
 	public function keyToolAlt():Int return -1;
+	public function isAvailable():Bool return true;
 }

--- a/src/level/editor/ToolBelt.hx
+++ b/src/level/editor/ToolBelt.hx
@@ -7,140 +7,150 @@ import util.Keys;
 
 class ToolBelt
 {
-  public var allTools:Map<String, Array<Tool>> = new Map();
-  public var keyToolFrom:Int;
-  public var currentKeyTool:Int = 0;
-  public var buttons:Array<ToolButton> = [];
-  public var current(get, null):Tool;
-  var tool:Tool = null;
+	public var allTools:Map<String, Array<Tool>> = new Map();
+	public var keyToolFrom:Int;
+	public var currentKeyTool:Int = 0;
+	public var buttons:Array<ToolButton> = [];
+	public var current(get, null):Tool;
+	var tool:Tool = null;
 
-  public function new()
-  {
-    for (i in 0...LayerDefinition.definitions.length)
-    {
-      var l = LayerDefinition.definitions[i];
-      if (allTools[l.id] == null) allTools[l.id] = l.tools;
-    }
-  }
+	public function new()
+	{
+		for (i in 0...LayerDefinition.definitions.length)
+		{
+			var l = LayerDefinition.definitions[i];
+			if (allTools[l.id] == null) allTools[l.id] = l.tools;
+		}
+	}
 
-  public function setKeyTool(key:Int):Bool
-  {
-    if (EDITOR.currentLayerEditor != null && currentKeyTool != key)
-    {
-      var tool:Int = -1;
+	public function setKeyTool(key:Int):Bool
+	{
+		if (EDITOR.currentLayerEditor != null && currentKeyTool != key)
+		{
+			var tool:Int = -1;
 
-      switch (key)
-      {
-        case Keys.Shift:
-          tool = current.keyToolShift();
-        case Keys.Ctrl, Keys.Cmd:
-          tool = current.keyToolCtrl();
-        case Keys.Alt:
-          tool = current.keyToolAlt();
-        default:
-          throw "Not a keytool key!";
-      }
+			switch (key)
+			{
+				case Keys.Shift:
+					tool = current.keyToolShift();
+				case Keys.Ctrl, Keys.Cmd:
+					tool = current.keyToolCtrl();
+				case Keys.Alt:
+					tool = current.keyToolAlt();
+				default:
+					throw "Not a keytool key!";
+			}
 
-      if (currentKeyTool == 0) keyToolFrom = EDITOR.currentLayerEditor.currentTool;
+			if (currentKeyTool == 0) keyToolFrom = EDITOR.currentLayerEditor.currentTool;
 
-      if (setTool(tool))
-      {
-        currentKeyTool = key;
-        refreshToolbar();
-      }
-      
-      return tool != -1;
-    }
-    return false;
-  }
+			if (setTool(tool))
+			{
+				currentKeyTool = key;
+				refreshToolbar();
+			}
+			
+			return tool != -1;
+		}
+		return false;
+	}
 
-  public function unsetKeyTool(key:Int):Bool
-  {
-    if (currentKeyTool == key)
-    {
-      currentKeyTool = 0;
-      setTool(keyToolFrom);
-      return true;
-    }
-    else return false;
-  }
+	public function unsetKeyTool(key:Int):Bool
+	{
+		if (currentKeyTool == key)
+		{
+			currentKeyTool = 0;
+			setTool(keyToolFrom);
+			return true;
+		}
+		else return false;
+	}
 
-  public function beforeSetLayer():Void
-  {
-    if (currentKeyTool != 0) unsetKeyTool(currentKeyTool);
+	public function beforeSetLayer():Void
+	{
+		if (currentKeyTool != 0) unsetKeyTool(currentKeyTool);
 
-    if (tool != null)
-    {
-      tool.deactivated();
-      tool = null;
-    }
-  }
+		if (tool != null)
+		{
+			tool.deactivated();
+			tool = null;
+		}
+	}
 
-  public function afterSetLayer():Void
-  {
-    if (EDITOR.currentLayerEditor == null) return;
-    setTool(EDITOR.currentLayerEditor.currentTool, true);
-    populateToolbar();
-  }
+	public function afterSetLayer():Void
+	{
+		if (EDITOR.currentLayerEditor == null) return;
+		setTool(EDITOR.currentLayerEditor.currentTool, true);
+		populateToolbar();
+	}
 
-  public function setTool(id:Int, ?force:Bool):Bool
-  {
-    if (force == null) force = false;
+	public function setTool(id:Int, ?force:Bool):Bool
+	{
+		if (force == null) force = false;
 
-    var layer = EDITOR.level.currentLayer.template.definition.id;
+		var layer = EDITOR.level.currentLayer.template.definition.id;
 
-    if (id >= 0 && (id != EDITOR.currentLayerEditor.currentTool || force) && id < allTools[layer].length)
-    {
-      EDITOR.currentLayerEditor.currentTool = id;
-      EDITOR.dirty();
-      EDITOR.locked = false;
+		if (id >= 0 && (id != EDITOR.currentLayerEditor.currentTool || force) && id < allTools[layer].length)
+		{
+			if (!allTools[layer][id].isAvailable()) return false;
+			
+			EDITOR.currentLayerEditor.currentTool = id;
+			EDITOR.dirty();
+			EDITOR.locked = false;
 
-      currentKeyTool = 0;
-      refreshToolbar();
+			currentKeyTool = 0;
+			refreshToolbar();
 
-      if (tool != null) tool.deactivated();
-      tool = allTools[layer][id];
-      tool.activated();
+			if (tool != null) tool.deactivated();
+			tool = allTools[layer][id];
+			tool.activated();
 
-      return true;
-    }
+			return true;
+		}
 
-    return false;
-  }
+		return false;
+	}
 
-  public function populateToolbar():Void
-  {
-    var tools = allTools[EDITOR.level.currentLayer.template.definition.id];
-    var toolbar = new JQuery(".sticker-toolbar");
-    buttons.resize(0);
+	public function populateToolbar():Void
+	{
+		var tools = allTools[EDITOR.level.currentLayer.template.definition.id];
+		var toolbar = new JQuery(".sticker-toolbar");
+		buttons.resize(0);
 
-    toolbar.empty();
-    for (i in 0...tools.length)
-    {
-      var button = new ToolButton(tools[i], i);
-      buttons.push(button);
-      toolbar.append(button.element);
-    }
+		toolbar.empty();
+		for (i in 0...tools.length)
+		{
+			var button = new ToolButton(tools[i], i);
+			buttons.push(button);
+			toolbar.append(button.element);
+		}
 
-    refreshToolbar();
-  }
+		refreshToolbar();
+	}
 
-  public function refreshToolbar():Void
-  {
-    for (i in 0...buttons.length)
-    {
-      if (i == EDITOR.currentLayerEditor.currentTool)
-      {
-        if (currentKeyTool != 0) buttons[i].keyToolSelected();
-        else buttons[i].selected();
-      }
-      else if (currentKeyTool != 0 && keyToolFrom == i) buttons[i].keyToolSwapped();
-      else buttons[i].notSelected();
-    }
-  }
+	public function refreshToolbar():Void
+	{
+		for (i in 0...buttons.length)
+		{
+			if (i == EDITOR.currentLayerEditor.currentTool)
+			{
+				if (currentKeyTool != 0) buttons[i].keyToolSelected();
+				else buttons[i].selected();
+			}
+			else if (currentKeyTool != 0 && keyToolFrom == i) buttons[i].keyToolSwapped();
+			else buttons[i].notSelected();
+		}
 
-  function get_current(): Tool
-  {
-    return tool;
-  }
+	}
+
+	function get_current(): Tool
+	{
+		return tool;
+	}
+
+	public function checkAvailability()
+	{
+		for (button in buttons) button.tool.isAvailable() ? button.available() : button.unavailable();
+	}
+	
+
 }

--- a/src/level/editor/ui/ToolButton.hx
+++ b/src/level/editor/ui/ToolButton.hx
@@ -5,15 +5,20 @@ import js.jquery.JQuery;
 class ToolButton
 {
     public var element:JQuery;
+    public var tool:Tool;
+    public var id:Int;
 
     public function new(tool:Tool, id:Int)
     {
 		  element = new JQuery('<div title="${tool.getName()} [$id]" class="tool icon icon-${tool.getIcon()}" id="${tool.getName()}">');
       element.click(function (e)
       {
+        if (element.hasClass('unavailable')) return;
         EDITOR.toolBelt.setTool(id);
         EDITOR.toolBelt.refreshToolbar();
       });
+      this.tool = tool;
+      this.id = id;
     }
 
     public function keyToolSelected():Void
@@ -37,6 +42,14 @@ class ToolButton
     public function notSelected():Void
     {
       clearState();
+    }
+
+    public function available() {
+      element.removeClass('unavailable');
+    }
+
+    public function unavailable() {
+      element.addClass('unavailable');
     }
 
     public function clearState():Void

--- a/src/modules/decals/tools/DecalResizeTool.hx
+++ b/src/modules/decals/tools/DecalResizeTool.hx
@@ -92,5 +92,6 @@ class DecalResizeTool extends DecalTool
 	override public function keyToolCtrl():Int return resizing ? -1 : 0;
 	override public function keyToolAlt():Int return 1;
 	override public function keyToolShift():Int return 3;
+	override function isAvailable():Bool return layerEditor.selected.length > 0;
 
 }

--- a/src/modules/decals/tools/DecalRotateTool.hx
+++ b/src/modules/decals/tools/DecalRotateTool.hx
@@ -118,5 +118,6 @@ class DecalRotateTool extends DecalTool
 	override public function keyToolCtrl():Int return 0;
 	override public function keyToolAlt():Int return 1;
 	override public function keyToolShift():Int return 2;
+	override function isAvailable() return layerEditor.selected.length > 0;
 
 }

--- a/src/modules/entities/tools/EntityNodeTool.hx
+++ b/src/modules/entities/tools/EntityNodeTool.hx
@@ -96,5 +96,11 @@ class EntityNodeTool extends EntityTool
 	override public function getIcon():String return "entity-nodes";
 	override public function getName():String return "Add Node";
 	override public function keyToolAlt():Int return 1;
+	override function isAvailable():Bool {
+		for (entity in layerEditor.entities.list) {
+			for (e_id in layerEditor.selection.ids) if (entity.id == e_id && entity.template.hasNodes) return true;
+		}
+		return false;
+	}
 
 }

--- a/src/modules/entities/tools/EntityResizeTool.hx
+++ b/src/modules/entities/tools/EntityResizeTool.hx
@@ -106,5 +106,11 @@ class EntityResizeTool extends EntityTool
 	override public function keyToolCtrl():Int return 0;
 	override public function keyToolAlt():Int return 1;
 	override public function keyToolShift():Int return 3;
+	override function isAvailable():Bool {
+		for (entity in layerEditor.entities.list) {
+			for (e_id in layerEditor.selection.ids) if (entity.id == e_id && (entity.template.resizeableX || entity.template.resizeableY)) return true;
+		}
+		return false;
+	}
 
 }

--- a/src/modules/entities/tools/EntityRotateTool.hx
+++ b/src/modules/entities/tools/EntityRotateTool.hx
@@ -120,5 +120,11 @@ class EntityRotateTool extends EntityTool
 	override public function keyToolCtrl():Int return 0;
 	override public function keyToolAlt():Int return 1;
 	override public function keyToolShift():Int return 2;
+	override function isAvailable():Bool {
+		for (entity in layerEditor.entities.list) {
+			for (e_id in layerEditor.selection.ids) if (entity.id == e_id && entity.template.rotatable) return true;
+		}
+		return false;
+	}
 
 }


### PR DESCRIPTION
Looking to add #73  
wasn't sure if I should check a tool's availability in `Editor.drawLevel()` - it seems to be a decent spot, it seemed like `ToolBelt.refreshToolbar()` was where it'd make the most sense but that doesn't really get called often enough.