### PR TITLE
Snap to zoom

### DIFF
--- a/src/level/data/Level.hx
+++ b/src/level/data/Level.hx
@@ -306,6 +306,15 @@ class Level
 		EDITOR.handles.refresh();
 	}
 
+	public function setZoom(zoom:Float) {
+		camera.scale(zoom, zoom);
+		updateCameraInverse();
+		EDITOR.dirty();
+
+		EDITOR.updateZoomReadout();
+		EDITOR.handles.refresh();
+	}
+
 	public function zoomCameraAt(zoom:Float, x:Float, y:Float):Void
 	{
 		setZoomRect(zoom);

--- a/src/level/data/Level.hx
+++ b/src/level/data/Level.hx
@@ -309,6 +309,8 @@ class Level
 	public function setZoom(zoom:Float) {
 		camera.scale(zoom, zoom);
 		updateCameraInverse();
+		while (camera.a < 0.01 ) setZoom(0.01);
+		while (camera.a > 32 ) setZoom(-0.001);
 		EDITOR.dirty();
 
 		EDITOR.updateZoomReadout();
@@ -323,6 +325,8 @@ class Level
 		camera.scale(1 + .1 * zoom, 1 + .1 * zoom);
 		moveCamera(-x, -y);
 		updateCameraInverse();
+		while (camera.a < 0.01 ) zoomCameraAt(0.01, x, y);
+		while (camera.a > 32 ) zoomCameraAt(-0.001, x, y);
 		EDITOR.dirty();
 
 		EDITOR.updateZoomReadout();

--- a/src/level/editor/Editor.hx
+++ b/src/level/editor/Editor.hx
@@ -220,6 +220,11 @@ class Editor
 				});
 			});
 
+			new JQuery('.sticker-zoom').click((e) -> {
+				var zoom = (EDITOR.level.zoom.round() / EDITOR.level.zoom).max(1 / EDITOR.level.zoom);
+				EDITOR.level.setZoom(zoom);
+			});
+
 			Remote.getCurrentWindow().on('focus', function (e)
 			{
 				EDITOR.levelManager.onGainFocus();


### PR DESCRIPTION
This branch does a couple of things:
- click on the zoom readout to snap zoom to the nearest 100% (min 100%)
- prevent zoom amounts less than 1% and greater than 3200%