### PR TITLE
Add Project Hooks

### DIFF
--- a/src/level/data/Level.hx
+++ b/src/level/data/Level.hx
@@ -121,6 +121,10 @@ class Level
 		for (layer in layers)
 			data.layers.push(layer.save());
 
+		if (project.scriptObject && project.scriptObject.saveLevel) {
+			data = project.scriptObject.saveLevel(project, data);
+		}
+		
 		return data;
 	}
 

--- a/src/level/data/Level.hx
+++ b/src/level/data/Level.hx
@@ -121,10 +121,8 @@ class Level
 		for (layer in layers)
 			data.layers.push(layer.save());
 
-		if (project.scriptObject && project.scriptObject.saveLevel) {
-			data = project.scriptObject.saveLevel(project, data);
-		}
-		
+		data = project.projectHooks.BeforeSaveLevel(project, data);
+
 		return data;
 	}
 

--- a/src/level/data/Level.hx
+++ b/src/level/data/Level.hx
@@ -78,6 +78,8 @@ class Level
 	
 	public function load(data:Dynamic):Level
 	{
+		data = this.project.projectHooks.BeforeLoadLevel(this.project, data);
+
 		this.data.loadFrom(data);
 		values = Imports.values(data, OGMO.project.levelValues);
 		

--- a/src/project/data/Project.hx
+++ b/src/project/data/Project.hx
@@ -174,7 +174,7 @@ class Project
 		entities.refreshTagLists();
 
 		// load user project hooks
-		var scriptLocation:String = getAbsoluteLevelPath(externalScript);
+		var scriptLocation:String = externalScript != null ? getAbsoluteLevelPath(externalScript) : "";
 		projectHooks = new ProjectHooks(scriptLocation);
 
 		initLastSavePath();

--- a/src/project/data/ProjectHooks.hx
+++ b/src/project/data/ProjectHooks.hx
@@ -1,0 +1,48 @@
+package project.data;
+
+import sys.io.File;
+import js.node.vm.Script;
+
+class ProjectHooks
+{
+  private var script:Script;
+  private var beforeSaveLevelFn:Dynamic;
+  private var beforeSaveProjectFn:Dynamic;
+
+  public function new(scriptFile:String) {
+    if (scriptFile.length <= 0) {
+      return;
+    }
+
+    if (!sys.FileSystem.exists(scriptFile)) {
+      return;
+    }
+
+    var contents:String = File.getContent(scriptFile);
+    script = new Script(contents, {filename: scriptFile});
+    var scriptObject:Dynamic = script.runInThisContext();
+
+    if (js.Lib.typeof(scriptObject) != "object") {
+      return;
+    }
+
+    beforeSaveLevelFn = js.Lib.typeof(scriptObject.beforeSaveLevel) == "function" ? scriptObject.beforeSaveLevel : null;
+    beforeSaveProjectFn = js.Lib.typeof(scriptObject.beforeSaveProject) == "function" ? scriptObject.beforeSaveProject : null; 
+  }
+
+  public function BeforeSaveLevel(project:Project, data:Dynamic):Dynamic {
+    if (beforeSaveLevelFn == null) {
+      return data;
+    }
+    
+    return beforeSaveLevelFn(project, data);
+  }
+
+  public function BeforeSaveProject(project:Project, data:Dynamic):Dynamic {
+    if (beforeSaveProjectFn == null) {
+      return data;
+    }
+    
+    return beforeSaveProjectFn(project, data);
+  }
+}

--- a/src/project/data/ProjectHooks.hx
+++ b/src/project/data/ProjectHooks.hx
@@ -6,6 +6,7 @@ import js.node.vm.Script;
 class ProjectHooks
 {
   private var script:Script;
+  private var beforeLoadLevelFn:Dynamic;
   private var beforeSaveLevelFn:Dynamic;
   private var beforeSaveProjectFn:Dynamic;
 
@@ -26,8 +27,17 @@ class ProjectHooks
       return;
     }
 
+    beforeLoadLevelFn = js.Lib.typeof(scriptObject.beforeLoadLevel) == "function" ? scriptObject.beforeLoadLevel : null;
     beforeSaveLevelFn = js.Lib.typeof(scriptObject.beforeSaveLevel) == "function" ? scriptObject.beforeSaveLevel : null;
     beforeSaveProjectFn = js.Lib.typeof(scriptObject.beforeSaveProject) == "function" ? scriptObject.beforeSaveProject : null; 
+  }
+
+  public function BeforeLoadLevel(project:Project, data:Dynamic):Dynamic {
+    if (beforeLoadLevelFn == null) {
+      return data;
+    }
+    
+    return beforeLoadLevelFn(project, data);
   }
 
   public function BeforeSaveLevel(project:Project, data:Dynamic):Dynamic {

--- a/src/project/editor/ProjectGeneralPanel.hx
+++ b/src/project/editor/ProjectGeneralPanel.hx
@@ -14,6 +14,7 @@ class ProjectGeneralPanel extends ProjectEditorPanel
 
   public var projectName:JQuery;
   public var backgroundColor:JQuery;
+  public var externalScript:JQuery;
   public var gridColor:JQuery;
   public var angleExport:JQuery;
   public var directoryDepth:JQuery;
@@ -33,6 +34,9 @@ class ProjectGeneralPanel extends ProjectEditorPanel
 
     directoryDepth = Fields.createField("00", "5");
     Fields.createSettingsBlock(root, directoryDepth, SettingsBlock.Third, "Project Directory Depth", SettingsBlock.InlineTitle);
+
+    externalScript = Fields.createField("External Script Location");
+    Fields.createSettingsBlock(root, externalScript, SettingsBlock.Full, "External Script Location", SettingsBlock.InlineTitle);
 
     backgroundColor = Fields.createColor("Background Color", Color.white, root);
     Fields.createSettingsBlock(root, backgroundColor, SettingsBlock.Half, "Bg Color", SettingsBlock.InlineTitle);
@@ -72,6 +76,7 @@ class ProjectGeneralPanel extends ProjectEditorPanel
     Fields.setColor(backgroundColor, OGMO.project.backgroundColor);
     Fields.setColor(gridColor, OGMO.project.gridColor);
     compactExport.val(!OGMO.project.compactExport ? "0" : "1");
+    Fields.setField(externalScript, OGMO.project.externalScript);
     angleExport.val(OGMO.project.anglesRadians ? "0" : "1");
     Fields.setVector(layerGridDefaultSize, OGMO.project.layerGridDefaultSize);
     Fields.setVector(levelMinSize, OGMO.project.levelMinSize);
@@ -88,6 +93,7 @@ class ProjectGeneralPanel extends ProjectEditorPanel
     OGMO.project.backgroundColor = Fields.getColor(backgroundColor);
     OGMO.project.gridColor = Fields.getColor(gridColor);
     OGMO.project.compactExport = compactExport.val() != "0";
+    OGMO.project.externalScript = externalScript.val();
     OGMO.project.anglesRadians = angleExport.val() == "0";
     OGMO.project.layerGridDefaultSize = Fields.getVector(layerGridDefaultSize);
     OGMO.project.levelMinSize = Fields.getVector(levelMinSize);


### PR DESCRIPTION
This PR adds basic support for loading in per-project hooks, written in JS and stored relative to the project file. This allows users to customize the output in ways that Ogmo may not necessarily want to support directly. In my case I'd like to replace -1 tiles with 0, and include more tileset information inside the map instead of inside the project.

As a user, setting up the hook is done through the normal project editor, by specifying the relative path from the project directory to a `.js` file. When a project is loaded, the editor will attempt to run the specified JS file in the editor's context. This means that they have access to Ogmo's globals. This can be sandboxed if desired, but I've left it open to let access to stuff like setInterval, require, alert, console.log, and so on. Hook scripts can be debugged through Toggle Developer Tools just like the rest of Ogmo (the script should appear under "(no domain)"), or found through Cmd/Ctrl+P. The return value of `runInThisContext` is the value of the last statement executed in JS, so hook scripts can wrap an object in `()` so that Ogmo receives the object inside.

Currently, there are two override points: right before the level is saved, and right before the project is saved. The ProjectHooks class does all the proper checks so that the calling code just needs to call the corresponding ProjectHooks function. It may be possible to do things in a more type-safe manner, but I am using `js.Lib.typeof` to check if they're calling a JS function. I don't do anything for exceptions at the moment. I'm not sure if it makes sense to catch hook exceptions and just continue on as normal or not.

Here's an example hook file:

```js
{
  const fs = require('fs');
  alert(`fs is ${fs}`);

  ({
    beforeSaveLevel: (project, data) => {
      console.log('saving thing');
      data.customThing = "hooray" + Math.random();
      return data;
    },

    beforeSaveProject: (project, data) => {
      console.log('saving project!');
      data.customProjectThing = "awesome";
      return data;
    }
  })
}
```

I don't love the outer brackets, and then the ({ }) for the returning object, but the outer brackets are needed so that multiple executions don't attempt to redefine the top level const, and then ({ }) will make sure that object gets returned to Ogmo.

You should see the alert fire when transitioning into the editor from the project view, confirming that the script can require other modules, and that extra field should appear in any saved levels and projects.