### PR TITLE
Copied tile flip/rotate from Tiled

### DIFF
--- a/src/modules/tiles/TileLayer.hx
+++ b/src/modules/tiles/TileLayer.hx
@@ -220,28 +220,28 @@ class TileLayer extends Layer
 		if (template.arrayMode == ONE)
 		{
 			var tileFlagsCanary:Int = 0;
-			data.tileFlags = new Array<Int>();
+			var tileFlags = new Array<Int>();
 			for (column in flippedData) for (tile in column)
 			{
 				var flags = tile.encodeFlags();
 				tileFlagsCanary |= flags;
-				data.tileFlags.push(flags);
+				tileFlags.push(flags);
 			}
-			if (tileFlagsCanary == 0)
-				data.tileFlags = new Array<Int>();
+			if (tileFlagsCanary != 0)
+				data.tileFlags = tileFlags;
 		}
 		else if (template.arrayMode == TWO)
 		{
 			var tileFlagsCanary:Int = 0;
-			data.tileFlags2D = Calc.createArray2D(gridCellsY, gridCellsX, TileData.EMPTY_TILE);
+			var tileFlags2D = Calc.createArray2D(gridCellsY, gridCellsX, TileData.EMPTY_TILE);
 			for (x in 0...flippedData.length) for (y in 0...flippedData[x].length)
 			{
 				var flags = flippedData[x][y].encodeFlags();
 				tileFlagsCanary |= flags;
-				data.tileFlags2D[x][y] = flags;
+				tileFlags2D[x][y] = flags;
 			}
-			if (tileFlagsCanary == 0)
-				data.tileFlags2D = new Array<Array<Int>>();
+			if (tileFlagsCanary != 0)
+				data.tileFlags2D = tileFlags2D;
 		}
 
 		data.exportMode = template.exportMode;

--- a/src/modules/tiles/TileLayer.hx
+++ b/src/modules/tiles/TileLayer.hx
@@ -4,27 +4,20 @@ import level.data.Level;
 import project.data.Tileset;
 import level.data.Layer;
 
-// Clockwise, in degrees
-@:enum
-abstract TileRotation(Float) {
-  var None = 0;
-  var Ninety = 90;
-  var OneEighty = 180;
-  var TwoSeventy = 270;
-}
-
 class TileData
 {
-	static final FLAG_FLIP_HORIZONTAL		= 0x40000000;
-	static final FLAG_FLIP_VERTICAL			= 0x20000000;
-	static final FLAG_FLIP_ANTIDIAGONALLY	= 0x10000000;
+	static public inline var EMPTY_TILE = -1; // TODO - It might be nice to be able to set this to 0 -01010111
 
-	public var idx = -1; // TODO - It might be nice to be able to set this to 0 -01010111
+	static public inline var FLAG_FLIP_HORIZONTAL		= 0x40000000;
+	static public inline var FLAG_FLIP_VERTICAL		= 0x20000000;
+	static public inline var FLAG_FLIP_ANTIDIAGONALLY	= 0x10000000;
+
+	public var idx = EMPTY_TILE;
 	public var flipX = false;
 	public var flipY = false;
 	public var flipAntiDiagonally = false;
 
-	public function new(idx:Int = -1) // TODO - It might be nice to be able to set this to 0 -01010111
+	public function new(idx:Int = EMPTY_TILE)
 	{
 		this.idx = idx;
 	}
@@ -46,6 +39,11 @@ class TileData
 			flipX == rhs.flipX &&
 			flipY == rhs.flipY &&
 			flipAntiDiagonally == rhs.flipAntiDiagonally;
+	}
+
+	public function isEmptyTile():Bool
+	{
+		return idx == EMPTY_TILE;
 	}
 
 	static public function encodeInt(tile:TileData, value:Int):Int
@@ -150,7 +148,7 @@ class TileLayer extends Layer
 			else if (template.arrayMode == TWO)
 			{
 				data._contents = "data2D";
-				data.data2D = Calc.createArray2D(gridCellsX, gridCellsY, -1);
+				data.data2D = Calc.createArray2D(gridCellsX, gridCellsY, TileData.EMPTY_TILE);
 				for (x in 0...flippedData.length) for (y in 0...flippedData[x].length) data.data2D[x][y] = flippedData[x][y].encode();
 			}
 			else throw "Invalid Tile Layer Array Mode: " + template.arrayMode;
@@ -160,7 +158,7 @@ class TileLayer extends Layer
 			if(template.arrayMode == ONE)
 			{
 				data._contents = "dataCoords";
-				data.dataCoords = [for(column in flippedData) for (tile in column) tile.idx == -1 ? [-1] : [TileData.encodeInt(tile, tileset.getTileX(tile.idx)), tileset.getTileY(tile.idx)]];
+				data.dataCoords = [for(column in flippedData) for (tile in column) tile.isEmptyTile() ? [TileData.EMPTY_TILE] : [TileData.encodeInt(tile, tileset.getTileX(tile.idx)), tileset.getTileY(tile.idx)]];
 			}
 			else if (template.arrayMode == TWO)
 			{
@@ -171,7 +169,7 @@ class TileLayer extends Layer
 					for (x in 0...flippedData[y].length)
 					{
 						var tile = flippedData[y][x];
-						arr[y][x] = tile.idx == -1 ? [-1] : [TileData.encodeInt(tile, tileset.getTileX(tile.idx)), tileset.getTileY(tile.idx)];
+						arr[y][x] = tile.isEmptyTile() ? [TileData.EMPTY_TILE] : [TileData.encodeInt(tile, tileset.getTileX(tile.idx)), tileset.getTileY(tile.idx)];
 					}
 				}
 				data._contents = "dataCoords2D";
@@ -229,7 +227,7 @@ class TileLayer extends Layer
 				{
 					var x = i % gridCellsX;
 					var y = (i / gridCellsX).int();
-					if (content[i][0] == -1) this.data[y][x].idx = -1;
+					if (content[i][0] == TileData.EMPTY_TILE) this.data[y][x].idx = TileData.EMPTY_TILE;
 					else
 					{
 						var decodedX = TileData.decodeInt(this.data[y][x], content[i][0]);
@@ -244,7 +242,7 @@ class TileLayer extends Layer
 				{
 					for (x in 0...content[y].length)
 					{
-						if (content[y][x][0] == -1) this.data[y][x].idx = -1;
+						if (content[y][x][0] == TileData.EMPTY_TILE) this.data[y][x].idx = TileData.EMPTY_TILE;
 						else
 						{
 							var decodedX = TileData.decodeInt(this.data[y][x], content[y][x][0]);

--- a/src/modules/tiles/TileLayer.hx
+++ b/src/modules/tiles/TileLayer.hx
@@ -9,7 +9,7 @@ class TileData
 	static public inline var EMPTY_TILE = -1; // TODO - It might be nice to be able to set this to 0 -01010111
 
 	static public inline var FLAG_FLIP_HORIZONTAL		= 0x40000000;
-	static public inline var FLAG_FLIP_VERTICAL		= 0x20000000;
+	static public inline var FLAG_FLIP_VERTICAL			= 0x20000000;
 	static public inline var FLAG_FLIP_ANTIDIAGONALLY	= 0x10000000;
 
 	public var idx = EMPTY_TILE;
@@ -62,7 +62,9 @@ class TileData
 		tile.flipX = (value & FLAG_FLIP_HORIZONTAL) > 0;
 		tile.flipY = (value & FLAG_FLIP_VERTICAL) > 0;
 		tile.flipAntiDiagonally = (value & FLAG_FLIP_ANTIDIAGONALLY) > 0;
-		tile.idx = value & ~(FLAG_FLIP_HORIZONTAL | FLAG_FLIP_VERTICAL | FLAG_FLIP_ANTIDIAGONALLY);
+		tile.idx = Std.int(Math.abs(value)) & ~(FLAG_FLIP_HORIZONTAL | FLAG_FLIP_VERTICAL | FLAG_FLIP_ANTIDIAGONALLY);
+		if (value < 0)
+			tile.idx *= -1;
 		return tile.idx;
 	}
 

--- a/src/modules/tiles/TileLayerEditor.hx
+++ b/src/modules/tiles/TileLayerEditor.hx
@@ -1,10 +1,11 @@
 package modules.tiles;
 
+import modules.tiles.TileLayer.TileData;
 import level.editor.LayerEditor;
 
 class TileLayerEditor extends LayerEditor
 {
-	public var brush:Array<Array<Int>> = [[0]];
+	public var brush:Array<Array<TileData>> = [[new TileData(0)]];
 	public var brushIsContiguous(get, never):Bool;
 	public var brushRectangle(get, never):Rectangle;
 
@@ -18,7 +19,8 @@ class TileLayerEditor extends LayerEditor
 		for (x in 0...layer.gridCellsX) for (y in 0...layer.gridCellsY)
 		{
 			var l:TileLayer = cast layer;
-			if (l.data[x][y] != -1) EDITOR.draw.drawTile(x * l.template.gridSize.x, y * layer.template.gridSize.y, l.tileset, l.data[x][y]);
+			var tile = l.data[x][y];
+			if (tile.idx != -1) EDITOR.draw.drawTile(x * l.template.gridSize.x, y * layer.template.gridSize.y, l.tileset, tile);
 		}
 	}
 	
@@ -32,8 +34,8 @@ class TileLayerEditor extends LayerEditor
 		if (brushIsContiguous)
 		{
 			var layer:TileLayer = cast this.layer;
-			var atX = layer.tileset.getTileX(brush[0][0]);
-			var atY = layer.tileset.getTileY(brush[0][0]);
+			var atX = layer.tileset.getTileX(brush[0][0].idx);
+			var atY = layer.tileset.getTileY(brush[0][0].idx);
 			atX += x;
 			atY += y;
 
@@ -56,9 +58,29 @@ class TileLayerEditor extends LayerEditor
 		}
 	}
 
+	public function flipBrush(horizontal:Bool):Void
+	{
+		var newBrush = Calc.createArray2D(brush.length, brush[0].length, new TileData());
+		if (horizontal)
+			for (x in 0...brush.length) for (y in 0...brush[x].length) newBrush[brush.length - 1 - x][y] = brush[x][y];
+		else
+			for (x in 0...brush.length) for (y in 0...brush[x].length) newBrush[x][brush[x].length - 1 - y] = brush[x][y];
+		brush = newBrush;
+	}
+
+	public function rotateBrush(clockwise:Bool):Void
+	{
+		var newBrush = Calc.createArray2D(brush[0].length, brush.length, new TileData());
+		if (clockwise)
+			for (x in 0...brush.length) for (y in 0...brush[x].length) newBrush[brush[x].length - 1 - y][x] = brush[x][y];
+		else
+			for (x in 0...brush.length) for (y in 0...brush[x].length) newBrush[y][brush.length - 1 - x] = brush[x][y];
+		brush = newBrush;
+	}
+
 	public function setBrushRect(topLeft:Int):Void
 	{
-		for (x in 0...brush.length) for (y in 0...brush[x].length) brush[x][y] = topLeft + x + y * (cast layer : TileLayer).tileset.tileColumns;
+		for (x in 0...brush.length) for (y in 0...brush[x].length) brush[x][y].idx = topLeft + x + y * (cast layer : TileLayer).tileset.tileColumns;
 	}
 
 	override function keyRepeat(key:Int):Void
@@ -81,7 +103,7 @@ class TileLayerEditor extends LayerEditor
 	{
 		for (x in 0...brush.length) for (y in 0...brush[x].length)
 		{
-			if (brush[x][y] == -1 || brush[x][y] != brush[0][0] + x + y * (cast layer : TileLayer).tileset.tileColumns)
+			if (brush[x][y].idx == -1 || brush[x][y].idx != brush[0][0].idx + x + y * (cast layer : TileLayer).tileset.tileColumns)
 				return false;
 		}
 		return true;
@@ -91,7 +113,7 @@ class TileLayerEditor extends LayerEditor
 	{
 		if (brushIsContiguous)
 		{
-			var first = brush[0][0];
+			var first = brush[0][0].idx;
 			var columns = (cast layer : TileLayer).tileset.tileColumns;
 			return new Rectangle(first % columns, Math.floor(first / columns), brush.length, brush[0].length);
 		}

--- a/src/modules/tiles/TileLayerEditor.hx
+++ b/src/modules/tiles/TileLayerEditor.hx
@@ -20,7 +20,7 @@ class TileLayerEditor extends LayerEditor
 		{
 			var l:TileLayer = cast layer;
 			var tile = l.data[x][y];
-			if (tile.idx != -1) EDITOR.draw.drawTile(x * l.template.gridSize.x, y * layer.template.gridSize.y, l.tileset, tile);
+			if (!tile.isEmptyTile()) EDITOR.draw.drawTile(x * l.template.gridSize.x, y * layer.template.gridSize.y, l.tileset, tile);
 		}
 	}
 	
@@ -103,7 +103,7 @@ class TileLayerEditor extends LayerEditor
 	{
 		for (x in 0...brush.length) for (y in 0...brush[x].length)
 		{
-			if (brush[x][y].idx == -1 || brush[x][y].idx != brush[0][0].idx + x + y * (cast layer : TileLayer).tileset.tileColumns)
+			if (brush[x][y].isEmptyTile() || brush[x][y].idx != brush[0][0].idx + x + y * (cast layer : TileLayer).tileset.tileColumns)
 				return false;
 		}
 		return true;

--- a/src/modules/tiles/TilePalettePanel.hx
+++ b/src/modules/tiles/TilePalettePanel.hx
@@ -1,5 +1,6 @@
 package modules.tiles;
 
+import modules.tiles.TileLayer.TileData;
 import js.Browser;
 import js.jquery.Event;
 import util.Matrix;
@@ -211,7 +212,7 @@ class TilePalettePanel extends SidePanel
 				for (y in 0...selection.height.floor())
 				{
 					var id:Int = selection.x.floor() + x + (selection.y.floor() + y) * columns;
-					layerEditor.brush[x].push(id);
+					layerEditor.brush[x].push(new TileData(id));
 				}
 			}
 

--- a/src/modules/tiles/tools/TileEyedropperTool.hx
+++ b/src/modules/tiles/tools/TileEyedropperTool.hx
@@ -1,5 +1,7 @@
 package modules.tiles.tools;
 
+import modules.tiles.TileLayer.TileData;
+
 class TileEyedropperTool extends TileTool
 {
 
@@ -51,10 +53,10 @@ class TileEyedropperTool extends TileTool
 			
 			if (rect.width > 0 && rect.height > 0)
 			{
-				var brush:Array<Array<Int>> = Calc.createArray2D(rect.width.int(), rect.height.int(), -1);
+				var brush:Array<Array<TileData>> = Calc.createArray2D(rect.width.int(), rect.height.int(), new TileData());
 				for (x in 0...rect.width.int())
 					for (y in 0...rect.height.int())
-						brush[x][y] = layer.data[rect.x.int() + x][rect.y.int() + y];
+						brush[x][y] = new TileData().copy(layer.data[rect.x.int() + x][rect.y.int() + y]);
 				layerEditor.brush = brush;
 				layerEditor.palettePanel.refresh();
 			}

--- a/src/modules/tiles/tools/TileFloodTool.hx
+++ b/src/modules/tiles/tools/TileFloodTool.hx
@@ -1,5 +1,6 @@
 package modules.tiles.tools;
 
+import modules.tiles.TileLayer.TileData;
 import util.Random;
 
 class TileFloodTool extends TileTool
@@ -11,10 +12,10 @@ class TileFloodTool extends TileTool
 
 	override public function onRightDown(pos:Vector)
 	{
-		doFlood(pos, [[-1]]); // TODO - It might be nice to be able to set this to 0 -01010111
+		doFlood(pos, [[new TileData()]]);
 	}
 
-	public function doFlood(pos:Vector, brush:Array<Array<Int>>)
+	public function doFlood(pos:Vector, brush:Array<Array<TileData>>)
 	{
 		layer.levelToGrid(pos, pos);
 
@@ -27,7 +28,7 @@ class TileFloodTool extends TileTool
 
 			var posX = pos.x.int();
 			var posY = pos.y.int();
-			var start = layer.data[posX][posY];
+			var start = new TileData().copy(layer.data[posX][posY]);
 			var check = [ pos ];
 			var draw:Array<Vector> = [];
 			while (check.length > 0)
@@ -36,20 +37,20 @@ class TileFloodTool extends TileTool
 				var x = cur.x.int();
 				var y = cur.y.int();
 				draw.push(cur);
-				layer.data[x][y] = -2;
+				layer.data[x][y].idx = -2;
 
-				if (x > 0 && layer.data[x - 1][y] == start)
+				if (x > 0 && layer.data[x - 1][y].equals(start))
 					check.push(new Vector(x - 1, y));
-				if (x < layer.gridCellsX - 1 && layer.data[x + 1][y] == start)
+				if (x < layer.gridCellsX - 1 && layer.data[x + 1][y].equals(start))
 					check.push(new Vector(x + 1, y));
-				if (y > 0 && layer.data[x][y - 1] == start)
+				if (y > 0 && layer.data[x][y - 1].equals(start))
 					check.push(new Vector(x, y - 1));
-				if (y < layer.gridCellsY - 1 && layer.data[x][y + 1] == start)
+				if (y < layer.gridCellsY - 1 && layer.data[x][y + 1].equals(start))
 					check.push(new Vector(x, y + 1));
 			}
 
 			for (p in draw)
-				layer.data[p.x.int()][p.y.int()] = start;
+				layer.data[p.x.int()][p.y.int()].copy(start);
 
 			for (p in draw)
 			{
@@ -57,19 +58,19 @@ class TileFloodTool extends TileTool
 				var pY = p.y.int();
 				var tile = brushAt(brush, pX - posX, pY - posY, random);
 
-				if (!first && layer.data[pX][pY] != tile)
+				if (!first && !layer.data[pX][pY].equals(tile))
 				{
 					first = true;
 					EDITOR.level.store("flood fill");
 					EDITOR.dirty();
 				}
 
-				layer.data[pX][pY] = tile;
+				layer.data[pX][pY].copy(tile);
 			}
 		}
 	}
 
-	public function canDrawAt(pos:Vector, brush:Array<Array<Int>>):Bool
+	public function canDrawAt(pos:Vector, brush:Array<Array<TileData>>):Bool
 	{
 		if (!layer.insideGrid(pos))
 			return false;
@@ -77,7 +78,7 @@ class TileFloodTool extends TileTool
 		var over = layer.data[pos.x.int()][pos.y.int()];
 		for (i in 0...brush.length)
 			for (j in 0...brush[i].length)
-				if (brush[i][j] != over)
+				if (!brush[i][j].equals(over))
 					return true;
 
 		return false;

--- a/src/modules/tiles/tools/TileLineTool.hx
+++ b/src/modules/tiles/tools/TileLineTool.hx
@@ -1,12 +1,13 @@
 package modules.tiles.tools;
 
 import util.Random;
+import modules.tiles.TileLayer.TileData;
 
 class TileLineTool extends TileTool
 {
 	public var drawing:Bool = false;
 	public var deleting:Bool = false;
-	public var brush:Array<Array<Int>>;
+	public var brush:Array<Array<TileData>>;
 	public var start:Vector = new Vector();
 	public var end:Vector = new Vector();
 	public var points:Array<Vector>;
@@ -101,7 +102,7 @@ class TileLineTool extends TileTool
 			drawing = true;
 			deleting = true;
 			start = end = pos;
-			brush = [[-1]]; // TODO - It might be nice to be able to set this to 0 -01010111
+			brush = [[new TileData()]];
 			updateLine();
 		}
 	}
@@ -119,6 +120,8 @@ class TileLineTool extends TileTool
 	
 	override public function onKeyPress(key:Int)
 	{
+		super.onKeyPress(key);
+
 		if (OGMO.keyIsCtrl(key))
 			EDITOR.overlayDirty();
 	}
@@ -143,7 +146,7 @@ class TileLineTool extends TileTool
 
 			for (p in points)
 			{
-				if (layer.insideGrid(p)) layer.data[p.x.int()][p.y.int()] = brushAt(brush, p.x.int() - start.x.int(), p.y.int() - start.y.int(), random);
+				if (layer.insideGrid(p)) layer.data[p.x.int()][p.y.int()].copy(brushAt(brush, p.x.int() - start.x.int(), p.y.int() - start.y.int(), random));
 			}
 		}
 	}
@@ -170,7 +173,7 @@ class TileLineTool extends TileTool
 		{
 			if (layer.insideGrid(p))
 			{
-				if (layer.data[p.x.int()][p.y.int()] != brushAt(brush, p.x.int() - start.x.int(), p.y.int() - start.y.int(), random))
+				if (!layer.data[p.x.int()][p.y.int()].equals(brushAt(brush, p.x.int() - start.x.int(), p.y.int() - start.y.int(), random)))
 				{
 					ret = true;
 					break;

--- a/src/modules/tiles/tools/TilePencilTool.hx
+++ b/src/modules/tiles/tools/TilePencilTool.hx
@@ -23,7 +23,7 @@ class TilePencilTool extends TileTool
 			if (OGMO.ctrl)
 			{
 				var tile = random.peekChoice2D(layerEditor.brush);
-				if (tile.idx != -1 && layer.insideGrid(prevPos))
+				if (!tile.isEmptyTile() && layer.insideGrid(prevPos))
 					EDITOR.overlay.drawTile(at.x, at.y, layer.tileset, tile);
 			}
 			else
@@ -33,7 +33,7 @@ class TilePencilTool extends TileTool
 					for (y in 0...layerEditor.brush[x].length)
 					{
 						var tile = layerEditor.brush[x][y];
-						if (tile.idx != -1)
+						if (!tile.isEmptyTile())
 						{
 							var cur = new Vector(at.x + x * layer.template.gridSize.x, at.y + y * layer.template.gridSize.y);
 							if (layer.insideGrid(new Vector(prevPos.x + x, prevPos.y + y)))

--- a/src/modules/tiles/tools/TilePencilTool.hx
+++ b/src/modules/tiles/tools/TilePencilTool.hx
@@ -1,5 +1,6 @@
 package modules.tiles.tools;
 
+import modules.tiles.TileLayer.TileData;
 import level.editor.LayerEditor;
 import util.Random;
 
@@ -7,7 +8,7 @@ class TilePencilTool extends TileTool
 {
 	public var drawing:Bool = false;
 	public var firstDraw:Bool = false;
-	public var drawBrush:Array<Array<Int>>;
+	public var drawBrush:Array<Array<TileData>>;
 	public var prevPos:Vector = new Vector();
 	public var lastRect:Rectangle = null;
 	public var random:Random = new Random();
@@ -22,7 +23,7 @@ class TilePencilTool extends TileTool
 			if (OGMO.ctrl)
 			{
 				var tile = random.peekChoice2D(layerEditor.brush);
-				if (tile != -1 && layer.insideGrid(prevPos))
+				if (tile.idx != -1 && layer.insideGrid(prevPos))
 					EDITOR.overlay.drawTile(at.x, at.y, layer.tileset, tile);
 			}
 			else
@@ -31,12 +32,12 @@ class TilePencilTool extends TileTool
 				{
 					for (y in 0...layerEditor.brush[x].length)
 					{
-						var id = layerEditor.brush[x][y];
-						if (id != -1)
+						var tile = layerEditor.brush[x][y];
+						if (tile.idx != -1)
 						{
 							var cur = new Vector(at.x + x * layer.template.gridSize.x, at.y + y * layer.template.gridSize.y);
 							if (layer.insideGrid(new Vector(prevPos.x + x, prevPos.y + y)))
-								EDITOR.overlay.drawTile(cur.x, cur.y, layer.tileset, id);
+								EDITOR.overlay.drawTile(cur.x, cur.y, layer.tileset, tile);
 						}
 					}
 				}
@@ -58,7 +59,7 @@ class TilePencilTool extends TileTool
 
 	override public function onRightDown(pos:Vector)
 	{
-		startDrawing(pos, [[-1]]); // TODO - It might be nice to be able to set this to 0 -01010111
+		startDrawing(pos, [[new TileData()]]);
 	}
 
 	override public function onMouseMove(pos:Vector)
@@ -87,7 +88,7 @@ class TilePencilTool extends TileTool
 		EDITOR.locked = false;
 	}
 
-	public function startDrawing(pos:Vector, tiles:Array<Array<Int>>)
+	public function startDrawing(pos:Vector, tiles:Array<Array<TileData>>)
 	{
 		layer.levelToGrid(pos, pos);
 		prevPos = pos;
@@ -117,7 +118,7 @@ class TilePencilTool extends TileTool
 				if (layer.insideGrid(pos))
 				{
 					var tile = random.nextChoice2D(drawBrush);
-					layer.data[px][py] = tile;
+					layer.data[px][py].copy(tile);
 
 					lastRect = new Rectangle(pos.x, pos.y, 1, 1);
 				}
@@ -127,7 +128,7 @@ class TilePencilTool extends TileTool
 				for (x in 0...drawBrush.length)
 					for (y in 0...drawBrush[x].length)
 						if (layer.insideGrid(new Vector(px + x, py + y)))
-							layer.data[px.int() + x][py.int() + y] = drawBrush[x][y];
+							layer.data[px.int() + x][py.int() + y].copy(drawBrush[x][y]);
 
 				lastRect = new Rectangle(pos.x, pos.y, drawBrush.length, drawBrush[0].length);
 			}
@@ -149,6 +150,8 @@ class TilePencilTool extends TileTool
 	
 	override public function onKeyPress(key:Int)
 	{
+		super.onKeyPress(key);
+
 		if (OGMO.keyIsCtrl(key))
 			EDITOR.overlayDirty();
 	}

--- a/src/modules/tiles/tools/TileRectangleTool.hx
+++ b/src/modules/tiles/tools/TileRectangleTool.hx
@@ -39,7 +39,7 @@ class TileRectangleTool extends TileTool
 				for (y in 0...rect.height.int())
 				{
 					var tile = brushAt(brush, rect.x.int() + x - start.x.int(), rect.y.int() + y - start.y.int(), random);
-					if (tile.idx != -1)
+					if (!tile.isEmptyTile())
 						EDITOR.overlay.drawTile(at.x + x * layer.template.gridSize.x, at.y + y * layer.template.gridSize.y, layer.tileset, tile);
 				}
 			}

--- a/src/modules/tiles/tools/TileRectangleTool.hx
+++ b/src/modules/tiles/tools/TileRectangleTool.hx
@@ -1,12 +1,13 @@
 package modules.tiles.tools;
 
+import modules.tiles.TileLayer.TileData;
 import util.Random;
 
 class TileRectangleTool extends TileTool
 {
 	public var drawing:Bool = false;
 	public var deleting:Bool = false;
-	public var brush:Array<Array<Int>>;
+	public var brush:Array<Array<TileData>>;
 	public var start:Vector = new Vector();
 	public var end:Vector = new Vector();
 	public var rect:Rectangle = new Rectangle();
@@ -38,7 +39,7 @@ class TileRectangleTool extends TileTool
 				for (y in 0...rect.height.int())
 				{
 					var tile = brushAt(brush, rect.x.int() + x - start.x.int(), rect.y.int() + y - start.y.int(), random);
-					if (tile != -1)
+					if (tile.idx != -1)
 						EDITOR.overlay.drawTile(at.x + x * layer.template.gridSize.x, at.y + y * layer.template.gridSize.y, layer.tileset, tile);
 				}
 			}
@@ -72,7 +73,7 @@ class TileRectangleTool extends TileTool
 		drawing = true;
 		deleting = true;
 		start = end = pos;
-		brush = [[-1]]; // TODO - It might be nice to be able to set this to 0 -01010111
+		brush = [[new TileData()]];
 		updateRect();
 	}
 
@@ -119,6 +120,8 @@ class TileRectangleTool extends TileTool
 
 	override public function onKeyPress(key:Int)
 	{
+		super.onKeyPress(key);
+
 		if (OGMO.keyIsCtrl(key))
 			EDITOR.overlayDirty();
 	}
@@ -143,7 +146,7 @@ class TileRectangleTool extends TileTool
 			EDITOR.level.store("rectangle fill");
 			for (i in 0...rect.width.int())
 				for (j in 0...rect.height.int())
-					layer.data[rect.x.int() + i][rect.y.int() + j] = brushAt(brush, rect.x.int() + i - start.x.int(), rect.y.int() + j - start.y.int(), random);
+					layer.data[rect.x.int() + i][rect.y.int() + j].copy(brushAt(brush, rect.x.int() + i - start.x.int(), rect.y.int() + j - start.y.int(), random));
 		}
 	}
 
@@ -162,7 +165,7 @@ class TileRectangleTool extends TileTool
 		{
 			for (j in 0...rect.height.int())
 			{
-				if (layer.data[rect.x.int() + i][rect.y.int() + j] != brushAt(brush, rect.x.int() + i - start.x.int(), rect.y.int() + j - start.y.int(), random))
+				if (!layer.data[rect.x.int() + i][rect.y.int() + j].equals(brushAt(brush, rect.x.int() + i - start.x.int(), rect.y.int() + j - start.y.int(), random)))
 				{
 					ret = true;
 					break;

--- a/src/modules/tiles/tools/TileSelectTool.hx
+++ b/src/modules/tiles/tools/TileSelectTool.hx
@@ -51,7 +51,7 @@ class TileSelectTool extends TileTool
 			var tile = selection[x][y];
 			var cur = new Vector(trueAt.x + x * layer.template.gridSize.x, trueAt.y + y * layer.template.gridSize.y);
 			if (!layer.insideGrid(new Vector(freeRect.x + x, freeRect.y + y))) continue;
-			if (tile.idx == -1) // TODO - It might be nice to be able to set this to 0 -01010111
+			if (tile.isEmptyTile())
 			{
 				if (!OGMO.ctrl) EDITOR.overlay.drawRect(cur.x, cur.y, layer.template.gridSize.x, layer.template.gridSize.y, Color.red.x(0.2));
 				continue;
@@ -90,8 +90,8 @@ class TileSelectTool extends TileTool
 		updateRect();
 		if (OGMO.ctrl) return; 
 		for (x in 0...rect.width.int()) for (y in 0...rect.height.int()) 
-			if (selection[x][y].idx != -1) // TODO - It might be nice to be able to set tile idx to 0 -01010111
-				layer.data[rect.x.int() + x][rect.y.int() + y] = new TileData(); // TODO - It might be nice to be able to set tile idx to 0 -01010111
+			if (!selection[x][y].isEmptyTile())
+				layer.data[rect.x.int() + x][rect.y.int() + y] = new TileData();
 		EDITOR.dirty();
 	}
 
@@ -145,7 +145,7 @@ class TileSelectTool extends TileTool
 		mode = None;
 		for (x in 0...freeRect.width.int()) for (y in 0...freeRect.height.int())
 		{
-			if (OGMO.ctrl && selection[x][y].idx == -1) continue; // TODO - It might be nice to be able to set this to 0 -01010111
+			if (OGMO.ctrl && selection[x][y].isEmptyTile()) continue;
 			if (layer.insideGrid(new Vector(freeRect.x + x, freeRect.y + y)))
 				layer.data[freeRect.x.int() + x][freeRect.y.int() + y].copy(selection[x][y]);
 		}
@@ -188,7 +188,7 @@ class TileSelectTool extends TileTool
 		for (x in 0...freeRect.width.int()) for (y in 0...freeRect.height.int())
 		{
 			if (layer.insideGrid(new Vector(freeRect.x + x, freeRect.y + y)))
-				layer.data[freeRect.x.int() + x][freeRect.y.int() + y] = new TileData(); // TODO - It might be nice to be able to set tile idx to 0 -01010111
+				layer.data[freeRect.x.int() + x][freeRect.y.int() + y] = new TileData();
 		}
 		EDITOR.dirty();
 		deselectTiles();

--- a/src/modules/tiles/tools/TileSelectTool.hx
+++ b/src/modules/tiles/tools/TileSelectTool.hx
@@ -1,5 +1,6 @@
 package modules.tiles.tools;
 
+import modules.tiles.TileLayer.TileData;
 import modules.tiles.tools.TileTool;
 
 class TileSelectTool extends TileTool
@@ -7,7 +8,7 @@ class TileSelectTool extends TileTool
 	var mode:SelectModes = None;
 	var start:Vector = new Vector();
 	var end:Vector = new Vector();
-	var selection:Array<Array<Int>> = [];
+	var selection:Array<Array<TileData>> = [];
 	var rect:Rectangle = new Rectangle();
 	var freeRect:Rectangle = new Rectangle();
 	var offset:Vector = new Vector();
@@ -47,16 +48,16 @@ class TileSelectTool extends TileTool
 		//EDITOR.overlay.setAlpha(0.75);
 		for (x in 0...selection.length) for (y in 0...selection[x].length)
 		{
-			var id = selection[x][y];
+			var tile = selection[x][y];
 			var cur = new Vector(trueAt.x + x * layer.template.gridSize.x, trueAt.y + y * layer.template.gridSize.y);
 			if (!layer.insideGrid(new Vector(freeRect.x + x, freeRect.y + y))) continue;
-			if (id == -1) // TODO - It might be nice to be able to set this to 0 -01010111
+			if (tile.idx == -1) // TODO - It might be nice to be able to set this to 0 -01010111
 			{
 				if (!OGMO.ctrl) EDITOR.overlay.drawRect(cur.x, cur.y, layer.template.gridSize.x, layer.template.gridSize.y, Color.red.x(0.2));
 				continue;
 			}
 			EDITOR.overlay.drawRect(cur.x, cur.y, layer.template.gridSize.x, layer.template.gridSize.y, Color.red.x(0.25));
-			EDITOR.overlay.drawTile(cur.x, cur.y, layer.tileset, id);
+			EDITOR.overlay.drawTile(cur.x, cur.y, layer.tileset, tile);
 			trace('\n at: ${at.x} / ${at.y} \n cur: ${cur.x} / ${cur.y}');
 		}
 		//EDITOR.overlay.setAlpha(1);
@@ -89,8 +90,8 @@ class TileSelectTool extends TileTool
 		updateRect();
 		if (OGMO.ctrl) return; 
 		for (x in 0...rect.width.int()) for (y in 0...rect.height.int()) 
-			if (selection[x][y] != -1) // TODO - It might be nice to be able to set this to 0 -01010111
-				layer.data[rect.x.int() + x][rect.y.int() + y] = -1; // TODO - It might be nice to be able to set this to 0 -01010111
+			if (selection[x][y].idx != -1) // TODO - It might be nice to be able to set tile idx to 0 -01010111
+				layer.data[rect.x.int() + x][rect.y.int() + y] = new TileData(); // TODO - It might be nice to be able to set tile idx to 0 -01010111
 		EDITOR.dirty();
 	}
 
@@ -135,8 +136,8 @@ class TileSelectTool extends TileTool
 		mode = None;
 		EDITOR.overlayDirty();
 		if (rect.width <= 0 || rect.height <= 0) return;
-		selection = Calc.createArray2D(rect.width.int(), rect.height.int(), -1); // TODO - It might be nice to be able to set this to 0 -01010111
-		for (x in 0...rect.width.int()) for (y in 0...rect.height.int()) selection[x][y] = layer.data[rect.x.int() + x][rect.y.int() + y];
+		selection = Calc.createArray2D(rect.width.int(), rect.height.int(), new TileData());
+		for (x in 0...rect.width.int()) for (y in 0...rect.height.int()) selection[x][y] = new TileData().copy(layer.data[rect.x.int() + x][rect.y.int() + y]);
 	}
 
 	function placeSelection(pos:Vector)
@@ -144,9 +145,9 @@ class TileSelectTool extends TileTool
 		mode = None;
 		for (x in 0...freeRect.width.int()) for (y in 0...freeRect.height.int())
 		{
-			if (OGMO.ctrl && selection[x][y] == -1) continue; // TODO - It might be nice to be able to set this to 0 -01010111
+			if (OGMO.ctrl && selection[x][y].idx == -1) continue; // TODO - It might be nice to be able to set this to 0 -01010111
 			if (layer.insideGrid(new Vector(freeRect.x + x, freeRect.y + y)))
-				layer.data[freeRect.x.int() + x][freeRect.y.int() + y] = selection[x][y];
+				layer.data[freeRect.x.int() + x][freeRect.y.int() + y].copy(selection[x][y]);
 		}
 		EDITOR.dirty();
 	}
@@ -187,7 +188,7 @@ class TileSelectTool extends TileTool
 		for (x in 0...freeRect.width.int()) for (y in 0...freeRect.height.int())
 		{
 			if (layer.insideGrid(new Vector(freeRect.x + x, freeRect.y + y)))
-				layer.data[freeRect.x.int() + x][freeRect.y.int() + y] = -1; // TODO - It might be nice to be able to set this to 0 -01010111
+				layer.data[freeRect.x.int() + x][freeRect.y.int() + y] = new TileData(); // TODO - It might be nice to be able to set tile idx to 0 -01010111
 		}
 		EDITOR.dirty();
 		deselectTiles();

--- a/src/modules/tiles/tools/TileTool.hx
+++ b/src/modules/tiles/tools/TileTool.hx
@@ -1,5 +1,6 @@
 package modules.tiles.tools;
 
+import modules.tiles.TileLayer.TileData;
 import level.editor.Tool;
 import util.Random;
 
@@ -11,7 +12,7 @@ class TileTool extends Tool
 	public var layer(get, never):TileLayer;
 	function get_layer():TileLayer return cast EDITOR.level.currentLayer;
 	
-	public function brushAt(brush:Array<Array<Int>>, x:Int, y:Int, ?random:Random):Int
+	public function brushAt(brush:Array<Array<TileData>>, x:Int, y:Int, ?random:Random):TileData
 	{
 		if (random == null)
 		{
@@ -26,8 +27,32 @@ class TileTool extends Tool
 		else return random.nextChoice2D(brush);
 	}
 	
-	public function brushRandom(brush:Array<Array<Int>>):Int
+	public function brushRandom(brush:Array<Array<TileData>>):TileData
 	{
 		return brush[Math.floor(Math.random() * brush.length)][Math.floor(Math.random() * brush[0].length)];
+	}
+
+	override public function onKeyPress(key:Int)
+	{
+		if (OGMO.keyIsCtrl(key)) return;
+		switch (key)
+		{
+			case H:
+				for (column in layerEditor.brush) for (tile in column) tile.doFlip(true);
+				layerEditor.flipBrush(true);
+				EDITOR.overlayDirty();
+			case V:
+				for (column in layerEditor.brush) for (tile in column) tile.doFlip(false);
+				layerEditor.flipBrush(false);
+				EDITOR.overlayDirty();
+			case R:
+				for (column in layerEditor.brush) for (tile in column) tile.doRotate(true);
+				layerEditor.rotateBrush(true);
+				EDITOR.overlayDirty();
+			case E:
+				for (column in layerEditor.brush) for (tile in column) tile.doRotate(false);
+				layerEditor.rotateBrush(false);
+				EDITOR.overlayDirty();
+		}
 	}
 }

--- a/src/rendering/GLRenderer.hx
+++ b/src/rendering/GLRenderer.hx
@@ -292,7 +292,7 @@ class GLRenderer
 		var botLeft = new Vector(-1, 1);
 		var botRight = new Vector(1, 1);
 
-		if (tile.flipAntiDiagonally)
+		if (tile.flipDiagonally)
 		{
 			topRight.copy(botLeft);
 			botLeft.set(1, -1);

--- a/src/rendering/GLRenderer.hx
+++ b/src/rendering/GLRenderer.hx
@@ -6,6 +6,7 @@ import js.html.webgl.RenderingContext;
 import js.html.webgl.Buffer;
 import js.Syntax;
 import project.data.Tileset;
+import modules.tiles.TileLayer;
 import util.Vector;
 import util.Color;
 import util.Rectangle;
@@ -277,27 +278,60 @@ class GLRenderer
 		uvs.push(uvy + uvh);
 	}
 
-	public function drawTile(x:Float, y:Float, tileset: Tileset, id: Int): Void
+	public function drawTile(x:Float, y:Float, tileset:Tileset, tile:TileData): Void
 	{
 		setTexture(tileset.texture);
 
-		var tx = (id % tileset.tileColumns);
-		var ty = Math.floor(id / tileset.tileColumns);
+		var tx = (tile.idx % tileset.tileColumns);
+		var ty = Math.floor(tile.idx / tileset.tileColumns);
 		var tw = tileset.tileWidth;
 		var th = tileset.tileHeight;
 
-		positions.push(x);
-		positions.push(y);
-		positions.push(x + tw);
-		positions.push(y);
-		positions.push(x);
-		positions.push(y + th);
-		positions.push(x + tw);
-		positions.push(y);
-		positions.push(x);
-		positions.push(y + th);
-		positions.push(x + tw);
-		positions.push(y + th);
+		var topLeft = new Vector(-1, -1);
+		var topRight = new Vector(1, -1);
+		var botLeft = new Vector(-1, 1);
+		var botRight = new Vector(1, 1);
+
+		if (tile.flipAntiDiagonally)
+		{
+			topRight.copy(botLeft);
+			botLeft.set(1, -1);
+		}
+		if (tile.flipX)
+		{
+			topLeft.x *= -1;
+			botLeft.x *= -1;
+			topRight.x *= -1;
+			botRight.x *= -1;
+		}
+		if (tile.flipY)
+		{
+			topLeft.y *= -1;
+			topRight.y *= -1;
+			botLeft.y *= -1;
+			botRight.y *= -1;
+		}
+
+		var tileOrigin = new Vector(x, y);
+		var tileWidth = new Vector(tw, th);
+		var half = new Vector(0.5, 0.5);
+		topLeft = topLeft.scale(0.5).add(half).mult(tileWidth).add(tileOrigin);
+		topRight = topRight.scale(0.5).add(half).mult(tileWidth).add(tileOrigin);
+		botLeft = botLeft.scale(0.5).add(half).mult(tileWidth).add(tileOrigin);
+		botRight = botRight.scale(0.5).add(half).mult(tileWidth).add(tileOrigin);
+
+		positions.push(topLeft.x);
+		positions.push(topLeft.y);
+		positions.push(topRight.x);
+		positions.push(topRight.y);
+		positions.push(botLeft.x);
+		positions.push(botLeft.y);
+		positions.push(topRight.x);
+		positions.push(topRight.y);
+		positions.push(botLeft.x);
+		positions.push(botLeft.y);
+		positions.push(botRight.x);
+		positions.push(botRight.y);
 
 		// use this to push in the UVs a bit to aVoid seems
 		var texel = new Vector(1 / tileset.width, 1 / tileset.height);


### PR DESCRIPTION
For feature request #128

Added persistent tile meta-data (TileData class) in the process which could be helpful for future tile features.

Use H/V/R/E keys to respectively flip brush horizontally, flip brush vertically, rotate brush clockwise, and rotate brush counter-clockwise.

For export it uses the highest 3 bits (signed 32 bit int) of the tile index to store flip/rotate info. For COORD export mode it uses the highest 3 bits of the x component, y is untouched. This isn't a breaking change for the format until flip/rotate is actively used in a level.

Perhaps an explicit project or layer setting to enable flip/rotate could be useful.

Tested all tile tools to the best of my ability.

Here are the references I used from Tiled:
1. https://doc.mapeditor.org/en/stable/reference/tmx-map-format/#tile-flipping
2. https://discourse.mapeditor.org/t/can-i-rotate-tiles/703/6
3. https://github.com/bjorn/tiled/issues/2119
4. https://github.com/bjorn/tiled/blob/1f5185e01aa3cbc60571ca9ffa4377d71f400ef9/src/libtiled/tilelayer.cpp#L394