### PR TITLE
Fixed settings.json path

### DIFF
--- a/src/Ogmo.hx
+++ b/src/Ogmo.hx
@@ -1,3 +1,4 @@
+import haxe.io.Path;
 import js.jquery.Event;
 import js.jquery.JQuery;
 import js.Browser;
@@ -31,6 +32,7 @@ class Ogmo
 	public var mouse:Vector = new Vector(0, 0);
 	public var popupMode:Bool = false;
 	public var root:String = untyped Remote.app.getAppPath();
+	public var execDir(get, never):String;
 
 	public var project(default, set):Project = null;
 	public var startTime(default, null):Float = js.lib.Date.now();
@@ -301,6 +303,15 @@ class Ogmo
 	function get_inputFocused():Bool
 	{
 		return (new JQuery('input:focus').length > 0 );
+	}
+
+	function get_execDir()
+	{
+		var isDev = root.indexOf('app.asar') == -1;
+		if (isDev)
+			return root;
+		else
+			return Path.directory(process.execPath);
 	}
 
 	function set_project(value:Project):Project

--- a/src/Ogmo.hx
+++ b/src/Ogmo.hx
@@ -1,7 +1,7 @@
-import haxe.io.Path;
 import js.jquery.Event;
 import js.jquery.JQuery;
 import js.Browser;
+import js.node.Path;
 import js.Node.process;
 import electron.main.BrowserWindow;
 import electron.renderer.Remote;
@@ -311,7 +311,7 @@ class Ogmo
 		if (isDev)
 			return root;
 		else
-			return Path.directory(process.execPath);
+			return Path.dirname(process.execPath);
 	}
 
 	function set_project(value:Project):Project

--- a/src/Settings.hx
+++ b/src/Settings.hx
@@ -1,5 +1,6 @@
 import util.RightClickMenu;
 import js.jquery.JQuery;
+import js.node.Path;
 import io.FileSystem;
 import project.data.Project;
 import project.data.ShapeData;
@@ -20,8 +21,7 @@ class Settings
 	public function new()
 	{
 		initShapes();
-		// TODO - not sure if this works atm -01010111
-		filepath = OGMO.root + 'settings.json';
+		filepath = Path.join(OGMO.execDir, 'settings.json');
 	}
 
 	public function save()


### PR DESCRIPTION
Right now our `settings.json` is `binsettings.json` in start + dev mode and `/resources/app.asarsettings.json` in dist mode.

Fix tested on Windows (start + dev + dist), need to verify Mac and Linux.

`Ogmo.root` (`getAppPath()` under the hood) returns `/bin` for start + dev and `/resources/app.asar` for dist.
Added an `Ogmo.execDir` property to use for `settings.json` that returns `/bin` for start + dev and the packaged executable's parent directory for dist.

It uses `process.execPath` under the hood:

![image](https://user-images.githubusercontent.com/3769354/85506458-6e781a80-b5be-11ea-9d70-1cc38f1efde9.png)

In dist mode our packaged executable is guaranteed to be the one to start node so this seems solid. But it still needs to be checked on Mac and Linux platforms.