### PR TITLE
Tile palette panel fix

### DIFF
--- a/src/modules/tiles/TilePalettePanel.hx
+++ b/src/modules/tiles/TilePalettePanel.hx
@@ -271,7 +271,7 @@ class TilePalettePanel extends SidePanel
 			{
 				image.addEventListener("load", function (e) {
 					refresh();
-				});
+				}, { once: true });
 				return;
 			}
 

--- a/src/modules/tiles/TilePalettePanel.hx
+++ b/src/modules/tiles/TilePalettePanel.hx
@@ -267,11 +267,11 @@ class TilePalettePanel extends SidePanel
 
 		if (tileset != null)
 		{
-			if (!image.complete)
+			if (image.width <= 0)
 			{
-				image.onload = function (e) {
+				image.addEventListener("load", function (e) {
 					refresh();
-				};
+				});
 				return;
 			}
 

--- a/src/modules/tiles/TilePalettePanel.hx
+++ b/src/modules/tiles/TilePalettePanel.hx
@@ -267,6 +267,14 @@ class TilePalettePanel extends SidePanel
 
 		if (tileset != null)
 		{
+			if (!image.complete)
+			{
+				image.onload = function (e) {
+					refresh();
+				};
+				return;
+			}
+
 			context.fillStyle = "rgb(220, 220, 220)";
 			context.fillRect(0, 0, canvas.width, canvas.height);
 


### PR DESCRIPTION
When I open a project the tile palette panel is blank until a `TilePalettePanel.refresh()` call is made. Here's a quick fix for that.

I don't believe it's worth rolling this into Texture.hx (as `function isLoaded()` and `function onLoad()`), unless the same pattern emerges elsewhere.