### PR TITLE
Quickfix for entity/decal list (scrollbar was hiding the title element)

### DIFF
--- a/src/assets/styles/editor.scss
+++ b/src/assets/styles/editor.scss
@@ -358,6 +358,7 @@
     {
         flex: 0 1;
         min-height: 30px;
+        overflow-x: hidden;
     }
 
     & .entityId


### PR DESCRIPTION
Happens often when a decal is selected:
![image](https://user-images.githubusercontent.com/3769354/86047722-56b8f000-ba1d-11ea-829c-993778328a98.png)

Fixed:
![image](https://user-images.githubusercontent.com/3769354/86047736-60425800-ba1d-11ea-91c1-d42538e8df9b.png)

User can resize the right panel to view the full title when it overflows:
![image](https://user-images.githubusercontent.com/3769354/86047873-997ac800-ba1d-11ea-91d1-6cf8cf78d2fd.png)

The changes only affect the right panel entity and decal list specifically (`.editor_selection .entityList`).