### PR TITLE
Quickfix for decal origin changing after undo/redo

### DIFF
--- a/src/modules/decals/Decal.hx
+++ b/src/modules/decals/Decal.hx
@@ -48,7 +48,7 @@ class Decal
 
 	public function clone():Decal
 	{
-		return new Decal(position, path, texture, scale, rotation, values);
+		return new Decal(position, path, texture, origin, scale, rotation, values);
 	}
 
 	function get_width():Int


### PR DESCRIPTION
origin argument was missing

Bug was:
* Create new decal
* Undo
* Redo
* Notice its origin is now (1, 1) and it's not at the same place it was on creation