### PR TITLE
Fix Entity layer undo/redo when entity selection isn't empty

### DIFF
--- a/src/modules/entities/EntityGroup.hx
+++ b/src/modules/entities/EntityGroup.hx
@@ -105,6 +105,7 @@ class EntityGroup
 				changed = true;
 				i--;
 			}
+			i++;
 		}
 	}
 


### PR DESCRIPTION
Bug repro steps:
* Create two entities
* Select one or both
* Undo
* Notice the app hangs in an infinite loop