### PR TITLE
Tileset margins backwards compatibility

### DIFF
--- a/src/project/data/Tileset.hx
+++ b/src/project/data/Tileset.hx
@@ -74,7 +74,15 @@ class Tileset
 	{
 		var img = Browser.document.createImageElement();
 		img.src = data.image;
-		return new Tileset(project, data.label, data.path, data.tileWidth, data.tileHeight, data.tileSeparationX, data.tileSeparationY, data.tileMarginX, data.tileMarginY, img);
+
+		var marginX:Int = 0;
+		if (Reflect.hasField(data, "tileMarginX"))
+			marginX = data.tileMarginX;
+		var marginY:Int = 0;
+		if (Reflect.hasField(data, "tileMarginY"))
+			marginY = data.tileMarginY;
+
+		return new Tileset(project, data.label, data.path, data.tileWidth, data.tileHeight, data.tileSeparationX, data.tileSeparationY, marginX, marginY, img);
 	}
 
 	public inline function getTileX(id: Int):Int return id % tileColumns;


### PR DESCRIPTION
Otherwise tilesets from old projects don't render (have some bogus margins)

The issue also goes away on its own if user re-saves their project but this prevents any surprises