### PR TITLE
Entity node tool improvements

### DIFF
--- a/src/modules/entities/EntityLayerEditor.hx
+++ b/src/modules/entities/EntityLayerEditor.hx
@@ -7,10 +7,52 @@ import rendering.FloatingHTML.FloatingHTMLPropertyDisplay;
 import rendering.FloatingHTML.PositionAlignV;
 import rendering.FloatingHTML.PositionAlignH;
 
+class EntityNodeID
+{
+	public static inline var ENTITY_NONE_ID:Int = -1;
+	public static inline var ROOT_NODE_ID:Int = -1;
+
+	public var entityID:Int;
+	public var nodeIdx:Int;
+
+	public function getNodePosition(entity:Entity):Vector
+	{
+		if (entityID == ENTITY_NONE_ID)
+			return null;
+		else if (nodeIdx == ROOT_NODE_ID)
+			return entity.position;
+		else if (nodeIdx >= entity.nodes.length)
+			return null;
+		else
+			return entity.nodes[nodeIdx];
+	}
+
+	public function new()
+	{
+		entityID = ENTITY_NONE_ID;
+		nodeIdx = ROOT_NODE_ID;
+	}
+
+	public function set(entityID:Int, nodeIdx:Int = ROOT_NODE_ID):Bool
+	{
+		var changed = this.entityID != entityID || this.nodeIdx != nodeIdx;
+		this.entityID = entityID;
+		this.nodeIdx = nodeIdx;
+
+		return changed;
+	}
+
+	public function isSet():Bool
+	{
+		return entityID != ENTITY_NONE_ID;
+	}
+}
+
 class EntityLayerEditor extends LayerEditor
 {
 	public var selection:EntityGroup = new EntityGroup();
 	public var hovered:EntityGroup = new EntityGroup();
+	public var hoveredNode:EntityNodeID = new EntityNodeID();
 	public var brush:Int = -1;
 	public var entities(get, never):EntityList;
 
@@ -28,6 +70,16 @@ class EntityLayerEditor extends LayerEditor
 		if (active && hovered.amount > 0)
 		{
 			for (ent in entities.getGroup(hovered)) ent.drawHoveredBox();
+		}
+		if (active && hoveredNode.isSet())
+		{
+			var ent = entities.getByID(hoveredNode.entityID);
+			if (ent != null)
+			{
+				var nodePos = hoveredNode.getNodePosition(ent);
+				if (nodePos != null)
+					ent.drawHoveredNodeBox(nodePos);
+			}
 		}
 
 		// Draw Entities

--- a/src/modules/entities/tools/EntityNodeTool.hx
+++ b/src/modules/entities/tools/EntityNodeTool.hx
@@ -1,22 +1,135 @@
 package modules.entities.tools;
 
+import modules.entities.EntityLayerEditor.EntityNodeID;
+
+class LineProjectionData
+{
+	public static inline var MAX_DISTANCE:Float = 6.0;
+
+	public var distance:Float;
+	public var projection:Vector;
+	public var entityID:Int;
+	public var nodeIdx:Int;
+
+	public function new(distance:Float, projection:Vector, entityID:Int, nodeIdx:Int)
+	{
+		this.distance = distance;
+		this.projection = projection;
+		this.entityID = entityID;
+		this.nodeIdx = nodeIdx;
+	}
+
+	public function active():Bool
+	{
+		return distance <= MAX_DISTANCE;
+	}
+}
+
 class EntityNodeTool extends EntityTool
 {
 
 	public var editing:Array<Vector> = [];
 	public var lastPos:Vector = new Vector();
 
+	private var closestProjection:LineProjectionData = null;
+	private var lastClosestProjection:LineProjectionData = null;
+
+	override function drawOverlay()
+	{
+		if (closestProjection != null && closestProjection.active())
+		{
+			var x = closestProjection.projection.x;
+			var y = closestProjection.projection.y;
+			var size = 8.0;
+			EDITOR.overlay.drawRect(x - size / 2.0, y - size / 2.0, size, size, Color.green.x(0.5));
+		}
+	}
+
 	override public function onMouseMove(pos:Vector)
 	{
+		closestProjection = null;
+
+		var entities = layer.entities.getGroupForNodes(layerEditor.selection);
+		var foundOne = false;
+		for (e in entities)	// Find hovered node
+		{
+			if (e.checkPoint(pos))
+			{
+				foundOne = true;
+				if (layerEditor.hoveredNode.set(e.id, EntityNodeID.ROOT_NODE_ID))
+					EDITOR.dirty();
+				break;
+			}
+
+			var nodeIdx = e.getNodeAt(pos);
+			if (nodeIdx != null)
+			{
+				foundOne = true;
+				if (layerEditor.hoveredNode.set(e.id, nodeIdx))
+					EDITOR.dirty();
+				break;
+			}
+		}
+		if (!foundOne)	// Find closest projection
+		{
+			if (layerEditor.hoveredNode.set(EntityNodeID.ENTITY_NONE_ID))
+				EDITOR.dirty();
+
+			var processProjection = function(projection:Vector, entityID:Int, nodeIdx:Int)
+			{
+				var distance = Vector.dist(pos, projection);
+				if (closestProjection == null || distance <= closestProjection.distance)
+					closestProjection = new LineProjectionData(distance, projection, entityID, nodeIdx);
+			};
+
+			var entities = layer.entities.getGroupForNodes(layerEditor.selection);
+			for (ent in entities)
+			{
+				if (!ent.canAddNode)
+					continue;
+
+				var display = ent.template.nodeDisplay;
+				if (display == NodeDisplayModes.PATH || display == NodeDisplayModes.CIRCUIT)
+				{
+					var prev:Vector = ent.position;
+					for (i in 0...ent.nodes.length)
+					{
+						var node = ent.nodes[i];
+						var projection = getPointToSegmentProjection(pos, prev, node);
+						if (projection != null)
+							processProjection(projection, ent.id, i);
+						prev = node;
+					}
+					if (display == NodeDisplayModes.CIRCUIT && ent.nodes.length > 1)
+					{
+						var projection = getPointToSegmentProjection(pos, prev, ent.position);
+						if (projection != null)
+							processProjection(projection, ent.id, ent.nodes.length);
+					}
+				}
+			}
+
+			if ((closestProjection != null && closestProjection.active()) ||
+				(lastClosestProjection != closestProjection)) // shallow compare for nulls, actual contents don't matter
+			{
+				lastClosestProjection = closestProjection;
+				EDITOR.overlayDirty();
+			}
+		}
+
 		if (editing.length > 0)
 		{
 			if (!OGMO.ctrl) layer.snapToGrid(pos, pos);
 			if (!pos.equals(lastPos))
 			{
-				for (p in editing) pos.clone(p);
+				for (p in editing)
+					p.add(pos.clone().sub(lastPos));
 				EDITOR.dirty();
 			}
 		}
+
+		pos.clone(lastPos);
+
 		// TODO - this is unused code - is there a feature behind it? -01010111
 		/*else
 		{
@@ -34,22 +147,39 @@ class EntityNodeTool extends EntityTool
 			EDITOR.locked = true;
 			EDITOR.level.store("add node(s)");
 
-			//Look for an existing node
+			//Look for an existing entity or node
 			for (e in entities)
 			{
-				var n = e.getNodeAt(pos);
-				if (n != null) editing.push(n);
+				if (e.checkPoint(pos))
+					editing.push(e.position);
+
+				var nodeIdx = e.getNodeAt(pos);
+				if (nodeIdx != null)
+					editing.push(e.nodes[nodeIdx]);
 			}
+
+			if (!OGMO.ctrl) layer.snapToGrid(pos, pos);
 
 			//If no existing nodes, create them
 			if (editing.length == 0)
 			{
-				if (!OGMO.ctrl) layer.snapToGrid(pos, pos);
-
 				for (e in entities)
 				{
-					var n = e.addNodeAt(pos);
-					if (n != null) editing.push(n);
+					if (e.canAddNode)
+					{
+						if (closestProjection != null && closestProjection.active() && e.id == closestProjection.entityID)
+						{
+							var n = closestProjection.projection.clone();
+							if (!OGMO.ctrl) layer.snapToGrid(n, n);
+							e.nodes.insert(closestProjection.nodeIdx, n);
+							editing.push(n);
+						}
+						else
+						{
+							var n = e.addNodeAt(pos);
+							editing.push(n);
+						}
+					}
 				}
 
 				EDITOR.dirty();
@@ -74,8 +204,8 @@ class EntityNodeTool extends EntityTool
 		//Look for an existing node
 		for (e in entities)
 		{
-			var n = e.getNodeAt(pos);
-			if (n != null) nodes.push({ entity: e, node: n });
+			var nodeIdx = e.getNodeAt(pos);
+			if (nodeIdx != null) nodes.push({ entity: e, node: e.nodes[nodeIdx] });
 		}
 
 		// delete them
@@ -88,6 +218,7 @@ class EntityNodeTool extends EntityTool
 				for (j in 0...entity.nodes.length) if (entity.nodes[j] == n.node) entity.nodes.splice(j, 1); // TODO - dunno if comparison will work here, might do `equals()`? -01010111
 			}
 
+			layerEditor.hoveredNode.set(EntityNodeID.ENTITY_NONE_ID);
 			EDITOR.dirty();
 		}
 	}
@@ -103,4 +234,24 @@ class EntityNodeTool extends EntityTool
 		return false;
 	}
 
+	private function getPointToSegmentProjection(point:Vector, start:Vector, end:Vector):Vector
+	{
+		var segmentDir = new Vector(end.x - start.x, end.y - start.y);
+		var segmentLength = segmentDir.length;
+
+		if (segmentLength < 0.01)
+			return null;
+
+		segmentDir.x /= segmentLength;
+		segmentDir.y /= segmentLength;
+
+		var localPoint = new Vector(point.x - start.x, point.y - start.y);
+
+		var dotProduct = Vector.dot(localPoint, segmentDir);
+		if (dotProduct < 0 || dotProduct > segmentLength)
+			return null;
+
+		var projection = new Vector(segmentDir.x * dotProduct + start.x, segmentDir.y * dotProduct + start.y);
+		return projection;
+	}
 }

--- a/src/modules/entities/tools/EntitySelectTool.hx
+++ b/src/modules/entities/tools/EntitySelectTool.hx
@@ -50,7 +50,7 @@ class EntitySelectTool extends EntityTool
 	{
 		mode = Move;
 		firstChange = false;
-		layer.snapToGrid(start, start);
+		if (!OGMO.ctrl) layer.snapToGrid(start, start);
 		entities = layer.entities.getGroup(layerEditor.selection);
 	}
 

--- a/src/util/Controls.hx
+++ b/src/util/Controls.hx
@@ -284,11 +284,11 @@ class Controls
         name: "Entity Node Tool",
         icon: "entity-nodes",
         controls: [
-            { keys: "Left Mouse", action: "Create and select a node for each selected entity snapped to grid. Or select existing node(s)." },
+            { keys: "Left Mouse", action: "Create and a node (for each selected entity) snapped to grid. Click on a path to create a node between two other nodes." },
             { subAction: true, keys: "Ctrl", action: "Don't snap to grid" },
-            { keys: "Left Mouse Drag + On Selected", action: "Move selected node(s), snapped to grid" },
+            { keys: "Left Mouse Drag + On Selected", action: "Move selected node, snapped to grid" },
             { subAction: true, keys: "Ctrl", action: "Don't snap to grid" },
-            { keys: "Right Mouse", action: "Delete node(s) under cursor" },
+            { keys: "Right Mouse", action: "Delete node under cursor" },
             { keys: "Alt", action: "Switch to Entity Create Tool" },
         ]
     };


### PR DESCRIPTION
Addresses #117 and half of #115 

Improvements:
* Mouse hover gfx
* Use entity hitbox like Entity Select Tool does, no need to snipe the origin anymore
* Can move the entity itself, no need anymore to switch to Entity Select Tool for that
* Can add nodes between existing nodes (for Path and Circuit display types)

Tested on all node display types.

Decided not to pursue selection or multi-selection because it would mean duplicating selection code from entity. It would make more sense to unify/generalize entity/node/decal selection code instead. This would also benefit future additions (ex: Shapes layer). One day.