### PR TITLE
Filepath property type

### DIFF
--- a/src/Settings.hx
+++ b/src/Settings.hx
@@ -58,7 +58,7 @@ class Settings
 	{
 		var maxRecentProjects = 50;
 		var data = {
-			path: project.path,
+			path: FileSystem.normalize(project.path),
 			name: project.name
 		};
 		var n = findProject(project.path);
@@ -82,7 +82,7 @@ class Settings
 
 	function findProject(path: String):Int
 	{
-		for (i in 0...recentProjects.length) if (recentProjects[i].path == path) return i;
+		for (i in 0...recentProjects.length) if (FileSystem.normalize(recentProjects[i].path) == FileSystem.normalize(path)) return i;
 		return -1;
 	}
 

--- a/src/io/Export.hx
+++ b/src/io/Export.hx
@@ -65,8 +65,8 @@ class Export
 
 	public static function color(color: Color, alpha:Bool):String
 	{
-		if (alpha) return color.toHex();
-		else return color.toHexAlpha();
+		if (alpha) return color.toHexAlpha();
+		else return color.toHex();
 	}
 
 	public static function values(into:Dynamic, values:Array<Value>)

--- a/src/io/FileSystem.hx
+++ b/src/io/FileSystem.hx
@@ -15,24 +15,36 @@ import electron.renderer.Remote;
 
 class FileSystem
 {
-
-	public static function chooseFile(title:String, filters:Array<FileFilter>)
+	// Resolves ., .., // + converts \ to /
+	public static function normalize(path:String):String
 	{
+		return haxe.io.Path.normalize(path);
+	}
+
+	public static function chooseFile(title:String, filters:Array<FileFilter>, ?defaultPath:String)
+	{
+		if (defaultPath != null)
+			defaultPath = js.node.Path.normalize(defaultPath); // Converts / back to \ on Windows, or else won't work
+
 		var files = Ogmo.dialog.showOpenDialog(
 			Remote.getCurrentWindow(),
 			{
 				title: title,
 				properties: ['openFile'],
-				filters: filters
+				filters: filters,
+				defaultPath: defaultPath
 			}
 		);
 
-		if (files != null) return files[0];
+		if (files != null) return normalize(files[0]);
 		return '';
 	}
 
 	public static function chooseSaveFile(title:String, filters:Array<FileFilter>, ?defaultPath:String):String
 	{
+		if (defaultPath != null)
+			defaultPath = js.node.Path.normalize(defaultPath); // Converts / back to \ on Windows, or else won't work
+
 		var file = Ogmo.dialog.showSaveDialog(
 			Remote.getCurrentWindow(),
 			{
@@ -41,7 +53,7 @@ class FileSystem
 				defaultPath: defaultPath
 			}
 		);
-		if (file != null) return file;
+		if (file != null) return normalize(file);
 		return '';
 	}
 
@@ -54,7 +66,7 @@ class FileSystem
 				properties: ['openDirectory']
 			}
 		);
-		if (files != null) return files[0];
+		if (files != null) return normalize(files[0]);
 		return '';
 	}
 

--- a/src/level/data/FilepathData.hx
+++ b/src/level/data/FilepathData.hx
@@ -1,0 +1,160 @@
+package level.data;
+
+import haxe.io.Path;
+
+enum RelativeTo
+{
+    PROJECT;
+    LEVEL;
+}
+
+class FilepathData
+{
+    public var relativeTo:RelativeTo;
+    public var path:String;
+
+    public function new(path:String = "", relativeTo:RelativeTo = RelativeTo.PROJECT)
+    {
+        this.path = path;
+        this.relativeTo = relativeTo;
+    }
+
+    public function clone():FilepathData
+    {
+        return new FilepathData(path, relativeTo);
+    }
+
+    public function asString():String
+    {
+        var prefix = "";
+        switch (relativeTo)
+        {
+            case PROJECT:
+                prefix = "proj";
+            case LEVEL:
+                prefix = "lvl";
+        }
+        return prefix + ":" + path;
+    }
+
+    public function parseString(str:String)
+    {
+        var projPrefix = "proj:";
+        var lvlPrefix = "lvl:";
+
+        if (str.length >= projPrefix.length && str.substr(0, projPrefix.length) == projPrefix)
+        {
+            relativeTo = RelativeTo.PROJECT;
+            path = str.substring(projPrefix.length, str.length);
+        }
+        else if (str.length >= lvlPrefix.length && str.substr(0, lvlPrefix.length) == lvlPrefix)
+        {
+            relativeTo = RelativeTo.LEVEL;
+            path = str.substring(lvlPrefix.length, str.length);
+        }
+        else
+        {
+            relativeTo = RelativeTo.PROJECT;
+            path = str;
+        }
+    }
+
+    public function save():Dynamic
+    {
+        var data = {
+            path: path,
+            relativeTo: Type.enumIndex(relativeTo),
+        };
+        return data;
+    }
+
+    public function load(data:Dynamic)
+    {
+        path = data.path;
+        relativeTo = Type.createEnumIndex(RelativeTo, data.relativeTo);
+    }
+
+    public function equals(to:FilepathData)
+    {
+        return path == to.path && relativeTo == to.relativeTo;
+    }
+
+    public function switchRelative(newRelativeTo:RelativeTo)
+    {
+        var base = getBase();
+        var newBase = newRelativeTo == RelativeTo.PROJECT ? getProjectDirectoryPath() : getLevelDirectoryPath();
+        relativeTo = newRelativeTo;
+
+        if (!validPath(path))
+            return;
+        if (base == null || newBase == null)
+            return;
+        if (base == newBase)
+            return;
+
+        var relative = js.node.Path.relative(newBase, base);
+        path = Path.join([relative, path]);
+        path = Path.normalize(path);
+
+        var fullPath = getFull();
+        fullPath = Path.normalize(fullPath);
+        path = js.node.Path.relative(newBase, fullPath);
+        path = Path.normalize(path);
+    }
+
+    public function getBase():String
+    {
+        switch (relativeTo)
+        {
+            case PROJECT:
+                var path = getProjectDirectoryPath();
+                if (validPath(path))
+                    return path;
+            case LEVEL:
+                var path = getLevelDirectoryPath();
+                if (validPath(path))
+                    return path;
+        }
+        return null;
+    }
+
+    public function getFull():String
+    {
+        var base = getBase();
+        if (validPath(base))
+        {
+            var full = Path.join([base, path]);
+            full = Path.normalize(full);
+            if (validPath(full))
+                return full;
+        }
+        return null;
+    }
+
+    public function getExtension():String
+    {
+        var ext = Path.extension(path);
+        if (validPath(ext))
+            return ext;
+        return null;
+    }
+
+    public static function getProjectDirectoryPath()
+    {
+        if (OGMO != null && OGMO.project != null && validPath(OGMO.project.path))
+            return Path.directory(OGMO.project.path);
+        return null;
+    }
+
+    public static function getLevelDirectoryPath()
+        {
+            if (EDITOR != null && EDITOR.level != null && validPath(EDITOR.level.path))
+                return Path.directory(EDITOR.level.path);
+            return null;
+        }
+
+    public static function validPath(path:String):Bool
+    {
+        return path != null && StringTools.trim(path).length > 0;
+    }
+}

--- a/src/level/data/FilepathData.hx
+++ b/src/level/data/FilepathData.hx
@@ -4,146 +4,146 @@ import haxe.io.Path;
 
 enum RelativeTo
 {
-    PROJECT;
-    LEVEL;
+	PROJECT;
+	LEVEL;
 }
 
 class FilepathData
 {
-    public var relativeTo:RelativeTo;
-    public var path:String;
+	public var relativeTo:RelativeTo;
+	public var path:String;
 
-    public function new(path:String = "", relativeTo:RelativeTo = RelativeTo.PROJECT)
-    {
-        this.path = path;
-        this.relativeTo = relativeTo;
-    }
+	public function new(path:String = "", relativeTo:RelativeTo = RelativeTo.PROJECT)
+	{
+		this.path = path;
+		this.relativeTo = relativeTo;
+	}
 
-    public function clone():FilepathData
-    {
-        return new FilepathData(path, relativeTo);
-    }
+	public function clone():FilepathData
+	{
+		return new FilepathData(path, relativeTo);
+	}
 
-    public function asString():String
-    {
-        var prefix = "";
-        switch (relativeTo)
-        {
-            case PROJECT:
-                prefix = "proj";
-            case LEVEL:
-                prefix = "lvl";
-        }
-        return prefix + ":" + path;
-    }
+	public function asString():String
+	{
+		var prefix = "";
+		switch (relativeTo)
+		{
+			case PROJECT:
+				prefix = "proj";
+			case LEVEL:
+				prefix = "lvl";
+		}
+		return prefix + ":" + path;
+	}
 
-    public static function parseString(str:String):FilepathData
-    {
-        var data = new FilepathData();
+	public static function parseString(str:String):FilepathData
+	{
+		var data = new FilepathData();
 
-        var projPrefix = "proj:";
-        var lvlPrefix = "lvl:";
+		var projPrefix = "proj:";
+		var lvlPrefix = "lvl:";
 
-        if (str.length >= projPrefix.length && str.substr(0, projPrefix.length) == projPrefix)
-        {
-            data.relativeTo = RelativeTo.PROJECT;
-            data.path = str.substring(projPrefix.length, str.length);
-        }
-        else if (str.length >= lvlPrefix.length && str.substr(0, lvlPrefix.length) == lvlPrefix)
-        {
-            data.relativeTo = RelativeTo.LEVEL;
-            data.path = str.substring(lvlPrefix.length, str.length);
-        }
-        else
-        {
-            data.relativeTo = RelativeTo.PROJECT;
-            data.path = str;
-        }
+		if (str.length >= projPrefix.length && str.substr(0, projPrefix.length) == projPrefix)
+		{
+			data.relativeTo = RelativeTo.PROJECT;
+			data.path = str.substring(projPrefix.length, str.length);
+		}
+		else if (str.length >= lvlPrefix.length && str.substr(0, lvlPrefix.length) == lvlPrefix)
+		{
+			data.relativeTo = RelativeTo.LEVEL;
+			data.path = str.substring(lvlPrefix.length, str.length);
+		}
+		else
+		{
+			data.relativeTo = RelativeTo.PROJECT;
+			data.path = str;
+		}
 
-        return data;
-    }
+		return data;
+	}
 
-    public function equals(to:FilepathData)
-    {
-        return path == to.path && relativeTo == to.relativeTo;
-    }
+	public function equals(to:FilepathData)
+	{
+		return path == to.path && relativeTo == to.relativeTo;
+	}
 
-    public function switchRelative(newRelativeTo:RelativeTo)
-    {
-        var base = getBase();
-        relativeTo = newRelativeTo;
-        var newBase = getBase();
+	public function switchRelative(newRelativeTo:RelativeTo)
+	{
+		var base = getBase();
+		relativeTo = newRelativeTo;
+		var newBase = getBase();
 
-        if (!validPath(path))
-            return;
-        if (base == null || newBase == null)
-            return;
-        if (base == newBase)
-            return;
+		if (!validPath(path))
+			return;
+		if (base == null || newBase == null)
+			return;
+		if (base == newBase)
+			return;
 
-        var relative = js.node.Path.relative(newBase, base);
-        path = Path.join([relative, path]);
-        path = Path.normalize(path);
+		var relative = js.node.Path.relative(newBase, base);
+		path = Path.join([relative, path]);
+		path = Path.normalize(path);
 
-        var fullPath = getFull();
-        fullPath = Path.normalize(fullPath);
-        path = js.node.Path.relative(newBase, fullPath);
-        path = Path.normalize(path);
-    }
+		var fullPath = getFull();
+		fullPath = Path.normalize(fullPath);
+		path = js.node.Path.relative(newBase, fullPath);
+		path = Path.normalize(path);
+	}
 
-    public function getBase():String
-    {
-        switch (relativeTo)
-        {
-            case PROJECT:
-                var path = getProjectDirectoryPath();
-                if (validPath(path))
-                    return path;
-            case LEVEL:
-                var path = getLevelDirectoryPath();
-                if (validPath(path))
-                    return path;
-        }
-        return null;
-    }
+	public function getBase():String
+	{
+		switch (relativeTo)
+		{
+			case PROJECT:
+				var path = getProjectDirectoryPath();
+				if (validPath(path))
+					return path;
+			case LEVEL:
+				var path = getLevelDirectoryPath();
+				if (validPath(path))
+					return path;
+		}
+		return null;
+	}
 
-    public function getFull():String
-    {
-        var base = getBase();
-        if (validPath(base))
-        {
-            var full = Path.join([base, path]);
-            full = Path.normalize(full);
-            if (validPath(full))
-                return full;
-        }
-        return null;
-    }
+	public function getFull():String
+	{
+		var base = getBase();
+		if (validPath(base))
+		{
+			var full = Path.join([base, path]);
+			full = Path.normalize(full);
+			if (validPath(full))
+				return full;
+		}
+		return null;
+	}
 
-    public function getExtension():String
-    {
-        var ext = Path.extension(path);
-        if (validPath(ext))
-            return ext;
-        return null;
-    }
+	public function getExtension():String
+	{
+		var ext = Path.extension(path);
+		if (validPath(ext))
+			return ext;
+		return null;
+	}
 
-    public static function getProjectDirectoryPath()
-    {
-        if (OGMO != null && OGMO.project != null && validPath(OGMO.project.path))
-            return Path.directory(OGMO.project.path);
-        return null;
-    }
+	public static function getProjectDirectoryPath()
+	{
+		if (OGMO != null && OGMO.project != null && validPath(OGMO.project.path))
+			return Path.directory(OGMO.project.path);
+		return null;
+	}
 
-    public static function getLevelDirectoryPath()
-        {
-            if (EDITOR != null && EDITOR.level != null && validPath(EDITOR.level.path))
-                return Path.directory(EDITOR.level.path);
-            return null;
-        }
+	public static function getLevelDirectoryPath()
+		{
+			if (EDITOR != null && EDITOR.level != null && validPath(EDITOR.level.path))
+				return Path.directory(EDITOR.level.path);
+			return null;
+		}
 
-    public static function validPath(path:String):Bool
-    {
-        return path != null && StringTools.trim(path).length > 0;
-    }
+	public static function validPath(path:String):Bool
+	{
+		return path != null && StringTools.trim(path).length > 0;
+	}
 }

--- a/src/level/data/FilepathData.hx
+++ b/src/level/data/FilepathData.hx
@@ -37,41 +37,30 @@ class FilepathData
         return prefix + ":" + path;
     }
 
-    public function parseString(str:String)
+    public static function parseString(str:String):FilepathData
     {
+        var data = new FilepathData();
+
         var projPrefix = "proj:";
         var lvlPrefix = "lvl:";
 
         if (str.length >= projPrefix.length && str.substr(0, projPrefix.length) == projPrefix)
         {
-            relativeTo = RelativeTo.PROJECT;
-            path = str.substring(projPrefix.length, str.length);
+            data.relativeTo = RelativeTo.PROJECT;
+            data.path = str.substring(projPrefix.length, str.length);
         }
         else if (str.length >= lvlPrefix.length && str.substr(0, lvlPrefix.length) == lvlPrefix)
         {
-            relativeTo = RelativeTo.LEVEL;
-            path = str.substring(lvlPrefix.length, str.length);
+            data.relativeTo = RelativeTo.LEVEL;
+            data.path = str.substring(lvlPrefix.length, str.length);
         }
         else
         {
-            relativeTo = RelativeTo.PROJECT;
-            path = str;
+            data.relativeTo = RelativeTo.PROJECT;
+            data.path = str;
         }
-    }
 
-    public function save():Dynamic
-    {
-        var data = {
-            path: path,
-            relativeTo: Type.enumIndex(relativeTo),
-        };
         return data;
-    }
-
-    public function load(data:Dynamic)
-    {
-        path = data.path;
-        relativeTo = Type.createEnumIndex(RelativeTo, data.relativeTo);
     }
 
     public function equals(to:FilepathData)
@@ -82,8 +71,8 @@ class FilepathData
     public function switchRelative(newRelativeTo:RelativeTo)
     {
         var base = getBase();
-        var newBase = newRelativeTo == RelativeTo.PROJECT ? getProjectDirectoryPath() : getLevelDirectoryPath();
         relativeTo = newRelativeTo;
+        var newBase = getBase();
 
         if (!validPath(path))
             return;

--- a/src/level/editor/value/FieldValueEditor.hx
+++ b/src/level/editor/value/FieldValueEditor.hx
@@ -71,7 +71,14 @@ class FieldValueEditor extends ValueEditor
 				lastValue = nextValue;
 				EDITOR.dirty();
 			});
-			element.on("keyup", function(e) { if (e.which == 13) element.blur(); });
+			element.on("keyup", function(e)
+			{
+				if (e.which == 13)
+				{
+					element.blur();
+					e.stopPropagation(); // Don't close popup
+				}
+			});
 		}
 	}
 

--- a/src/level/editor/value/FieldValueEditor.hx
+++ b/src/level/editor/value/FieldValueEditor.hx
@@ -71,14 +71,7 @@ class FieldValueEditor extends ValueEditor
 				lastValue = nextValue;
 				EDITOR.dirty();
 			});
-			element.on("keyup", function(e)
-			{
-				if (e.which == 13)
-				{
-					element.blur();
-					e.stopPropagation(); // Don't close popup
-				}
-			});
+			element.on("keyup", function(e) { if (e.which == Keys.Enter) element.blur(); });
 		}
 	}
 

--- a/src/level/editor/value/FilepathValueEditor.hx
+++ b/src/level/editor/value/FilepathValueEditor.hx
@@ -1,0 +1,202 @@
+package level.editor.value;
+
+import project.data.ValueDefinition;
+import project.data.value.FilepathValueTemplate;
+import js.node.Path;
+import level.data.FilepathData;
+import level.data.Value;
+import project.data.value.ValueTemplate;
+import js.jquery.JQuery;
+import util.Fields;
+
+class FilepathValueEditor extends ValueEditor
+{
+    public var title:String;
+    public var holder:JQuery = null;
+	public var element:JQuery = null;
+	public var baseButton:JQuery = null;
+	public var selectButton:JQuery = null;
+
+	override function load(template:ValueTemplate, values:Array<Value>):Void
+	{
+        var pathTemplate:FilepathValueTemplate = cast template;
+
+		title = template.name;
+
+		// check if values conflict
+        var value = new FilepathData();
+        value.parseString(values[0].value);
+        value = value.clone();
+		var conflictPath = false;
+		var conflictBase = false;
+		var i = 1;
+		while (i < values.length)
+		{
+            var curValue = new FilepathData();
+            curValue.parseString(values[i].value);
+			if (curValue.path != value.path)
+			{
+                conflictPath = true;
+                value.path = ValueEditor.conflictString();
+            }
+            if (curValue.relativeTo != value.relativeTo)
+            {
+                conflictBase = true;
+            }
+			i++;
+		}
+
+        var lastPathValue = value.path;
+        var lastBaseValue = conflictBase ? null : value.relativeTo;
+
+		// create element
+		{
+            holder = new JQuery('<div class="filepath">');
+
+            element = new JQuery('<input>');
+            if (conflictPath) element.addClass("default-value");
+            element.addClass(value.relativeTo == RelativeTo.PROJECT ? "relative_to_project" : "relative_to_level");
+            element.val(value.path);
+            element.change(function(e)
+            {
+                value.path = element.val();
+                var nextValue = new FilepathData();
+                nextValue.parseString(pathTemplate.validate(value.asString()));
+                var nextPathValue = nextValue.path;
+                if (lastPathValue != nextPathValue || conflictPath)
+                {
+                    EDITOR.level.store("Changed " + template.name + " Value from '" + lastPathValue + "' to '" + nextPathValue + "'");
+                    for (i in 0...values.length)
+                    {
+                        var data = new FilepathData();
+                        data.parseString(values[i].value);
+                        data.path = nextPathValue;
+                        values[i].value = data.asString();
+                    }
+                    conflictPath = false;
+                    lastPathValue = nextPathValue;
+                    EDITOR.dirty();
+                }
+                element.val(nextPathValue);
+            });
+            element.on("keyup", function(e)
+            {
+                if (e.which == 13)
+                {
+                    element.blur();
+                    e.stopPropagation(); // Don't close popup
+                }
+            });
+
+            var baseButtonLabel = value.relativeTo == RelativeTo.PROJECT ? "Project/" : "Level/";
+            if (conflictBase)
+                baseButtonLabel = ValueEditor.conflictString() + "/";
+            baseButton = Fields.createButton("", baseButtonLabel, holder);
+            baseButton.width("84px");
+            baseButton.on("click", function()
+            {
+                value.relativeTo = lastBaseValue == RelativeTo.PROJECT ? RelativeTo.LEVEL : RelativeTo.PROJECT;
+
+                var nextValue = new FilepathData();
+                nextValue.parseString(pathTemplate.validate(value.asString()));
+                var nextBaseValue = nextValue.relativeTo;
+                if (lastBaseValue != nextBaseValue || conflictBase)
+                {
+                    var nextPathValue:String = null;
+                    var from = nextBaseValue == RelativeTo.PROJECT ? "level" : "project";
+                    var to = nextBaseValue != RelativeTo.PROJECT ? "level" : "project";
+                    EDITOR.level.store("Changed " + template.name + " Reference from '" + from + "' to '" + to + "'");
+                    for (i in 0...values.length)
+                    {
+                        var data = new FilepathData();
+                        data.parseString(values[i].value);
+                        data.switchRelative(nextBaseValue);
+                        values[i].value = data.asString();
+                        nextPathValue = data.path;
+                    }
+                    conflictBase = false;
+                    lastBaseValue = nextBaseValue;
+                    EDITOR.dirty();
+
+                    if (!conflictPath)
+                    {
+                        value.path = nextPathValue;
+                        element.val(nextPathValue);
+                    }
+
+                    var btnText = nextBaseValue == RelativeTo.PROJECT ? "Project/" : "Level/";
+                    baseButton.find(".button_text").html(btnText);
+
+                    element.addClass(nextBaseValue == RelativeTo.PROJECT ? "relative_to_project" : "relative_to_level");
+                    element.removeClass(nextBaseValue != RelativeTo.PROJECT ? "relative_to_project" : "relative_to_level");
+                }
+            });
+
+            holder.append(element);
+
+            selectButton = Fields.createButton("save", "", holder);
+            selectButton.width("34px");
+            selectButton.on("click", function()
+            {
+                var projectDirPath = FilepathData.getProjectDirectoryPath();
+                var basePath = value.getBase();
+                var fullPath = value.getFull();
+                var initialPath = fullPath;
+                if (initialPath == null || !FileSystem.exists(initialPath))
+                    initialPath = basePath;
+                if (initialPath == null || !FileSystem.exists(initialPath))
+                    initialPath = projectDirPath;
+
+                var fileExtensions = pathTemplate.extensions.length == 0 ? [] : [{name: "Allowed extensions", extensions: pathTemplate.extensions}];
+                var chosenPath = FileSystem.chooseFile("Select Path", fileExtensions, initialPath);
+                if (chosenPath.length == 0)
+                    return;
+
+                var relativePath = FileSystem.normalize(Path.relative(basePath == null ? projectDirPath : basePath, chosenPath));
+                value.path = relativePath;
+
+                var nextValue = new FilepathData();
+                nextValue.parseString(pathTemplate.validate(value.asString()));
+                var nextPathValue = nextValue.path;
+                if (lastPathValue != nextPathValue || conflictPath)
+                {
+                    EDITOR.level.store("Changed " + template.name + " Path from '" + lastPathValue + "' to '" + nextPathValue + "'");
+                    for (i in 0...values.length)
+                    {
+                        var data = new FilepathData();
+                        data.parseString(values[i].value);
+                        data.path = nextPathValue;
+                        values[i].value = data.asString();
+                    }
+                    conflictPath = false;
+                    lastPathValue = nextPathValue;
+                    EDITOR.dirty();
+                }
+                element.val(nextPathValue);
+            });
+		}
+
+		// deal with conflict text inside the textarea
+        element.on("focus", function()
+        {
+            if (conflictPath)
+            {
+                element.val("");
+                element.removeClass("default-value");
+            }
+        });
+        element.on("blur", function()
+        {
+            if (conflictPath)
+            {
+                element.val(ValueEditor.conflictString());
+                element.addClass("default-value");
+            }
+        });
+	}
+
+	override function display(into:JQuery):Void
+	{
+		ValueEditor.createWrapper(title, holder, into);
+	}
+}

--- a/src/level/editor/value/FilepathValueEditor.hx
+++ b/src/level/editor/value/FilepathValueEditor.hx
@@ -11,174 +11,174 @@ import util.Fields;
 
 class FilepathValueEditor extends ValueEditor
 {
-    public var title:String;
-    public var holder:JQuery = null;
+	public var title:String;
+	public var holder:JQuery = null;
 	public var element:JQuery = null;
 	public var baseButton:JQuery = null;
 	public var selectButton:JQuery = null;
 
 	override function load(template:ValueTemplate, values:Array<Value>):Void
 	{
-        var pathTemplate:FilepathValueTemplate = cast template;
+		var pathTemplate:FilepathValueTemplate = cast template;
 
 		title = template.name;
 
 		// check if values conflict
-        var value = FilepathData.parseString(values[0].value);
+		var value = FilepathData.parseString(values[0].value);
 		var conflictPath = false;
 		var conflictBase = false;
 		var i = 1;
 		while (i < values.length)
 		{
-            var curValue = FilepathData.parseString(values[i].value);
+			var curValue = FilepathData.parseString(values[i].value);
 			if (curValue.path != value.path)
 			{
-                conflictPath = true;
-                value.path = ValueEditor.conflictString();
-            }
-            if (curValue.relativeTo != value.relativeTo)
-            {
-                conflictBase = true;
-            }
+				conflictPath = true;
+				value.path = ValueEditor.conflictString();
+			}
+			if (curValue.relativeTo != value.relativeTo)
+			{
+				conflictBase = true;
+			}
 			i++;
 		}
 
-        var lastPathValue = value.path;
-        var lastBaseValue = conflictBase ? null : value.relativeTo;
+		var lastPathValue = value.path;
+		var lastBaseValue = conflictBase ? null : value.relativeTo;
 
-        function savePath()
-        {
-            var nextValue = FilepathData.parseString(pathTemplate.validate(value.asString()));
-            var nextPathValue = nextValue.path;
-            if (lastPathValue != nextPathValue || conflictPath)
-            {
-                EDITOR.level.store("Changed " + template.name + " Path from '" + lastPathValue + "' to '" + nextPathValue + "'");
-                for (i in 0...values.length)
-                {
-                    var data = FilepathData.parseString(values[i].value);
-                    data.path = nextPathValue;
-                    values[i].value = data.asString();
-                }
-                conflictPath = false;
-                value.path = nextPathValue;
-                lastPathValue = nextPathValue;
-                EDITOR.dirty();
-            }
-        }
+		function savePath()
+		{
+			var nextValue = FilepathData.parseString(pathTemplate.validate(value.asString()));
+			var nextPathValue = nextValue.path;
+			if (lastPathValue != nextPathValue || conflictPath)
+			{
+				EDITOR.level.store("Changed " + template.name + " Path from '" + lastPathValue + "' to '" + nextPathValue + "'");
+				for (i in 0...values.length)
+				{
+					var data = FilepathData.parseString(values[i].value);
+					data.path = nextPathValue;
+					values[i].value = data.asString();
+				}
+				conflictPath = false;
+				value.path = nextPathValue;
+				lastPathValue = nextPathValue;
+				EDITOR.dirty();
+			}
+		}
 
-        function saveBase()
-        {
-            var nextValue = FilepathData.parseString(pathTemplate.validate(value.asString()));
-            var nextBaseValue = nextValue.relativeTo;
-            if (lastBaseValue != nextBaseValue || conflictBase)
-            {
-                var nextPathValue:String = null;
-                var from = nextBaseValue == RelativeTo.PROJECT ? "level" : "project";
-                var to = nextBaseValue != RelativeTo.PROJECT ? "level" : "project";
-                EDITOR.level.store("Changed " + template.name + " Reference from '" + from + "' to '" + to + "'");
-                for (i in 0...values.length)
-                {
-                    var data = FilepathData.parseString(values[i].value);
-                    data.switchRelative(nextBaseValue);
-                    values[i].value = data.asString();
-                    nextPathValue = data.path;
-                }
-                conflictBase = false;
-                value.relativeTo = nextBaseValue;
-                lastBaseValue = nextBaseValue;
-                EDITOR.dirty();
+		function saveBase()
+		{
+			var nextValue = FilepathData.parseString(pathTemplate.validate(value.asString()));
+			var nextBaseValue = nextValue.relativeTo;
+			if (lastBaseValue != nextBaseValue || conflictBase)
+			{
+				var nextPathValue:String = null;
+				var from = nextBaseValue == RelativeTo.PROJECT ? "level" : "project";
+				var to = nextBaseValue != RelativeTo.PROJECT ? "level" : "project";
+				EDITOR.level.store("Changed " + template.name + " Reference from '" + from + "' to '" + to + "'");
+				for (i in 0...values.length)
+				{
+					var data = FilepathData.parseString(values[i].value);
+					data.switchRelative(nextBaseValue);
+					values[i].value = data.asString();
+					nextPathValue = data.path;
+				}
+				conflictBase = false;
+				value.relativeTo = nextBaseValue;
+				lastBaseValue = nextBaseValue;
+				EDITOR.dirty();
 
-                if (!conflictPath)
-                    value.path = nextPathValue;
+				if (!conflictPath)
+					value.path = nextPathValue;
 
-                var btnText = nextBaseValue == RelativeTo.PROJECT ? "Project/" : "Level/";
-                baseButton.find(".button_text").html(btnText);
+				var btnText = nextBaseValue == RelativeTo.PROJECT ? "Project/" : "Level/";
+				baseButton.find(".button_text").html(btnText);
 
-                element.addClass(nextBaseValue == RelativeTo.PROJECT ? "relative_to_project" : "relative_to_level");
-                element.removeClass(nextBaseValue != RelativeTo.PROJECT ? "relative_to_project" : "relative_to_level");
-            }
-        }
+				element.addClass(nextBaseValue == RelativeTo.PROJECT ? "relative_to_project" : "relative_to_level");
+				element.removeClass(nextBaseValue != RelativeTo.PROJECT ? "relative_to_project" : "relative_to_level");
+			}
+		}
 
 		// create element
 		{
-            holder = new JQuery('<div class="filepath">');
+			holder = new JQuery('<div class="filepath">');
 
-            element = new JQuery('<input>');
-            if (conflictPath) element.addClass("default-value");
-            element.addClass(value.relativeTo == RelativeTo.PROJECT ? "relative_to_project" : "relative_to_level");
-            element.val(value.path);
-            element.change(function(e)
-            {
-                value.path = element.val();
-                savePath();
-                element.val(value.path);
-            });
-            element.on("keyup", function(e) { if (e.which == Keys.Enter) element.blur(); });
+			element = new JQuery('<input>');
+			if (conflictPath) element.addClass("default-value");
+			element.addClass(value.relativeTo == RelativeTo.PROJECT ? "relative_to_project" : "relative_to_level");
+			element.val(value.path);
+			element.change(function(e)
+			{
+				value.path = element.val();
+				savePath();
+				element.val(value.path);
+			});
+			element.on("keyup", function(e) { if (e.which == Keys.Enter) element.blur(); });
 
-            var baseButtonLabel = value.relativeTo == RelativeTo.PROJECT ? "Project/" : "Level/";
-            if (conflictBase)
-                baseButtonLabel = ValueEditor.conflictString() + "/";
-            baseButton = Fields.createButton("", baseButtonLabel, holder);
-            baseButton.width("84px");
-            baseButton.on("click", function()
-            {
-                value.relativeTo = lastBaseValue == RelativeTo.PROJECT ? RelativeTo.LEVEL : RelativeTo.PROJECT;
-                saveBase();
+			var baseButtonLabel = value.relativeTo == RelativeTo.PROJECT ? "Project/" : "Level/";
+			if (conflictBase)
+				baseButtonLabel = ValueEditor.conflictString() + "/";
+			baseButton = Fields.createButton("", baseButtonLabel, holder);
+			baseButton.width("84px");
+			baseButton.on("click", function()
+			{
+				value.relativeTo = lastBaseValue == RelativeTo.PROJECT ? RelativeTo.LEVEL : RelativeTo.PROJECT;
+				saveBase();
 
-                if (!conflictPath)
-                    element.val(value.path);
+				if (!conflictPath)
+					element.val(value.path);
 
-                var btnText = value.relativeTo == RelativeTo.PROJECT ? "Project/" : "Level/";
-                baseButton.find(".button_text").html(btnText);
+				var btnText = value.relativeTo == RelativeTo.PROJECT ? "Project/" : "Level/";
+				baseButton.find(".button_text").html(btnText);
 
-                element.addClass(value.relativeTo == RelativeTo.PROJECT ? "relative_to_project" : "relative_to_level");
-                element.removeClass(value.relativeTo != RelativeTo.PROJECT ? "relative_to_project" : "relative_to_level");
-            });
+				element.addClass(value.relativeTo == RelativeTo.PROJECT ? "relative_to_project" : "relative_to_level");
+				element.removeClass(value.relativeTo != RelativeTo.PROJECT ? "relative_to_project" : "relative_to_level");
+			});
 
-            holder.append(element);
+			holder.append(element);
 
-            selectButton = Fields.createButton("save", "", holder);
-            selectButton.width("34px");
-            selectButton.on("click", function()
-            {
-                var projectDirPath = FilepathData.getProjectDirectoryPath();
-                var basePath = value.getBase();
-                var fullPath = value.getFull();
-                var initialPath = fullPath;
-                if (initialPath == null || !FileSystem.exists(initialPath))
-                    initialPath = basePath;
-                if (initialPath == null || !FileSystem.exists(initialPath))
-                    initialPath = projectDirPath;
+			selectButton = Fields.createButton("save", "", holder);
+			selectButton.width("34px");
+			selectButton.on("click", function()
+			{
+				var projectDirPath = FilepathData.getProjectDirectoryPath();
+				var basePath = value.getBase();
+				var fullPath = value.getFull();
+				var initialPath = fullPath;
+				if (initialPath == null || !FileSystem.exists(initialPath))
+					initialPath = basePath;
+				if (initialPath == null || !FileSystem.exists(initialPath))
+					initialPath = projectDirPath;
 
-                var fileExtensions = pathTemplate.extensions.length == 0 ? [] : [{name: "Allowed extensions", extensions: pathTemplate.extensions}];
-                var chosenPath = FileSystem.chooseFile("Select Path", fileExtensions, initialPath);
-                if (chosenPath.length == 0)
-                    return;
+				var fileExtensions = pathTemplate.extensions.length == 0 ? [] : [{name: "Allowed extensions", extensions: pathTemplate.extensions}];
+				var chosenPath = FileSystem.chooseFile("Select Path", fileExtensions, initialPath);
+				if (chosenPath.length == 0)
+					return;
 
-                var relativePath = FileSystem.normalize(Path.relative(basePath == null ? projectDirPath : basePath, chosenPath));
-                value.path = relativePath;
-                savePath();
-                element.val(value.path);
-            });
+				var relativePath = FileSystem.normalize(Path.relative(basePath == null ? projectDirPath : basePath, chosenPath));
+				value.path = relativePath;
+				savePath();
+				element.val(value.path);
+			});
 		}
 
 		// deal with conflict text inside the textarea
-        element.on("focus", function()
-        {
-            if (conflictPath)
-            {
-                element.val("");
-                element.removeClass("default-value");
-            }
-        });
-        element.on("blur", function()
-        {
-            if (conflictPath)
-            {
-                element.val(ValueEditor.conflictString());
-                element.addClass("default-value");
-            }
-        });
+		element.on("focus", function()
+		{
+			if (conflictPath)
+			{
+				element.val("");
+				element.removeClass("default-value");
+			}
+		});
+		element.on("blur", function()
+		{
+			if (conflictPath)
+			{
+				element.val(ValueEditor.conflictString());
+				element.addClass("default-value");
+			}
+		});
 	}
 
 	override function display(into:JQuery):Void

--- a/src/modules/decals/Decal.hx
+++ b/src/modules/decals/Decal.hx
@@ -38,7 +38,7 @@ class Decal
 			data.scaleY = scale.y;
 		}
 		if (rotatable) data.rotation = OGMO.project.anglesRadians ? rotation : rotation * Calc.RTD;
-		data.texture = haxe.io.Path.normalize(path);
+		data.texture = FileSystem.normalize(path);
 		data.originX = origin.x;
 		data.originY = origin.y;
 		Export.values(data, values);

--- a/src/modules/entities/Entity.hx
+++ b/src/modules/entities/Entity.hx
@@ -97,7 +97,7 @@ class Entity
 		if (template.rotatable) data.rotation = OGMO.project.anglesRadians ? rotation * Calc.DTR : rotation;
 		if (template.canFlipX) data.flippedX = flippedX;
 		if (template.canFlipY) data.flippedY = flippedY;
-		if (template.canSetColor) data.color = Export.color(color, false);
+		if (template.canSetColor) data.color = Export.color(color, true);
 		Export.nodes(data, nodes);
 		Export.values(data, values);
 

--- a/src/modules/entities/EntityTemplate.hx
+++ b/src/modules/entities/EntityTemplate.hx
@@ -170,7 +170,7 @@ class EntityTemplate
 
 		if (texture != null) 
 		{
-			e.texture = haxe.io.Path.normalize(Path.relative(Path.dirname(OGMO.project.path), texture.path));
+			e.texture = FileSystem.normalize(Path.relative(Path.dirname(OGMO.project.path), texture.path));
 			e.textureImage = texture.image.src;
 		}
 

--- a/src/modules/tiles/ProjectTilesetsPanel.hx
+++ b/src/modules/tiles/ProjectTilesetsPanel.hx
@@ -59,7 +59,7 @@ class ProjectTilesetsPanel extends ProjectEditorPanel
 		var path = FileSystem.chooseFile("Select Tileset", [{ name: "Tilemaps", extensions: ["png", "jpg"] }]);
 		if (FileSystem.exists(path))
 		{
-			var relative = Path.relative(Path.dirname(OGMO.project.path), path);
+			var relative = FileSystem.normalize(Path.relative(Path.dirname(OGMO.project.path), path));
 			var tilemap = new Tileset(OGMO.project, "New Tileset", relative, 8, 8, 0, 0, 0, 0);
 
 			// delay a frame before refreshing to allow the tileset texture to load

--- a/src/project/data/value/FilepathValueTemplate.hx
+++ b/src/project/data/value/FilepathValueTemplate.hx
@@ -30,8 +30,7 @@ class FilepathValueTemplate extends ValueTemplate
 	{
 		if (extensions.length > 0)
 		{
-			var data:FilepathData = new FilepathData();
-			data.parseString(val);
+			var data:FilepathData = FilepathData.parseString(val);
 			if (FilepathData.validPath(data.path) && !extensions.contains(data.getExtension()))
 			{
 				var extensionsStr = extensions.join(",");
@@ -52,7 +51,7 @@ class FilepathValueTemplate extends ValueTemplate
 	override function load(data:Dynamic):Void
 	{
 		super.load(data);
-		defaults.parseString(data.defaults);
+		defaults = FilepathData.parseString(data.defaults);
 		extensions = data.extensions;
 	}
 

--- a/src/project/data/value/FilepathValueTemplate.hx
+++ b/src/project/data/value/FilepathValueTemplate.hx
@@ -1,0 +1,66 @@
+package project.data.value;
+
+import level.data.FilepathData;
+import project.editor.value.FilepathValueTemplateEditor;
+import level.editor.value.FilepathValueEditor;
+import level.editor.value.ValueEditor;
+import level.data.Value;
+
+class FilepathValueTemplate extends ValueTemplate
+{
+	public static function startup()
+	{
+		var n = new ValueDefinition(FilepathValueTemplate, FilepathValueTemplateEditor, "folder-open", "Filepath");
+		ValueDefinition.definitions.push(n);
+	}
+	public var defaults:FilepathData = new FilepathData();
+	public var extensions:Array<String> = [];
+
+	override function getHashCode():String
+	{
+		return name + ":fp:" + extensions.join(":");
+	}
+
+	override function getDefault():String
+	{
+		return defaults.asString();
+	}
+
+	override function validate(val:Dynamic):String
+	{
+		if (extensions.length > 0)
+		{
+			var data:FilepathData = new FilepathData();
+			data.parseString(val);
+			if (FilepathData.validPath(data.path) && !extensions.contains(data.getExtension()))
+			{
+				var extensionsStr = extensions.join(",");
+				data.path = 'Allowed: $extensionsStr';
+				return data.asString();
+			}
+		}
+		return val;
+	}
+
+	override function createEditor(values:Array<Value>):ValueEditor
+	{
+		var editor = new FilepathValueEditor();
+		editor.load(this, values);
+		return editor;
+	}
+
+	override function load(data:Dynamic):Void
+	{
+		super.load(data);
+		defaults.parseString(data.defaults);
+		extensions = data.extensions;
+	}
+
+	override function save():Dynamic
+	{
+		var data:Dynamic = super.save();
+		data.defaults = defaults.asString();
+		data.extensions = extensions;
+		return data;
+	}
+}

--- a/src/project/editor/value/FilepathValueTemplateEditor.hx
+++ b/src/project/editor/value/FilepathValueTemplateEditor.hx
@@ -1,0 +1,52 @@
+package project.editor.value;
+
+import js.jquery.JQuery;
+import project.data.value.FilepathValueTemplate;
+import util.Fields;
+
+class FilepathValueTemplateEditor extends ValueTemplateEditor
+{
+	public var nameField:JQuery;
+	public var defaultField:JQuery;
+	public var extensionsField:JQuery;
+
+	override function importInto(into:JQuery)
+	{
+		var pathTemplate:FilepathValueTemplate = cast template;
+
+		// name
+		nameField = Fields.createField("Name", pathTemplate.name);
+		Fields.createSettingsBlock(into, nameField, SettingsBlock.Half, "Name", SettingsBlock.InlineTitle);
+
+        // default val
+        var fileExtensions = pathTemplate.extensions.length == 0 ? [] : [{name: "Allowed extensions", extensions: pathTemplate.extensions}];
+		defaultField = Fields.createFilepathData(pathTemplate.defaults, fileExtensions);
+		Fields.createSettingsBlock(into, defaultField, SettingsBlock.Half, "Default", SettingsBlock.InlineTitle);
+
+		var extensions = "";
+		for (i in 0...pathTemplate.extensions.length) extensions += (i > 0 ? "\n" : "") + pathTemplate.extensions[i];
+
+		// extensions
+		extensionsField = Fields.createTextarea("...", extensions);
+        Fields.createSettingsBlock(into, extensionsField, SettingsBlock.Full, "Allowed extensions (one per line)");
+        extensionsField.on("input propertychange", function (e) { // Need to update extensions for default val picker
+            save();
+            fileExtensions.splice(0, fileExtensions.length);
+            if (pathTemplate.extensions.length > 0)
+                fileExtensions.push({name: "Allowed extensions", extensions: pathTemplate.extensions});
+        });
+	}
+
+	override function save()
+	{
+		var pathTemplate:FilepathValueTemplate = cast template;
+
+		pathTemplate.name = Fields.getField(nameField);
+		pathTemplate.defaults = Fields.getFilepathData(defaultField);
+		var extensions = StringTools.trim(Fields.getField(extensionsField));
+		if (extensions.length == 0)
+			pathTemplate.extensions = [];
+		else
+			pathTemplate.extensions = extensions.split("\n");
+	}
+}

--- a/src/project/editor/value/FilepathValueTemplateEditor.hx
+++ b/src/project/editor/value/FilepathValueTemplateEditor.hx
@@ -18,8 +18,8 @@ class FilepathValueTemplateEditor extends ValueTemplateEditor
 		nameField = Fields.createField("Name", pathTemplate.name);
 		Fields.createSettingsBlock(into, nameField, SettingsBlock.Half, "Name", SettingsBlock.InlineTitle);
 
-        // default val
-        var fileExtensions = pathTemplate.extensions.length == 0 ? [] : [{name: "Allowed extensions", extensions: pathTemplate.extensions}];
+		// default val
+		var fileExtensions = pathTemplate.extensions.length == 0 ? [] : [{name: "Allowed extensions", extensions: pathTemplate.extensions}];
 		defaultField = Fields.createFilepathData(pathTemplate.defaults, fileExtensions);
 		Fields.createSettingsBlock(into, defaultField, SettingsBlock.Half, "Default", SettingsBlock.InlineTitle);
 
@@ -28,13 +28,13 @@ class FilepathValueTemplateEditor extends ValueTemplateEditor
 
 		// extensions
 		extensionsField = Fields.createTextarea("...", extensions);
-        Fields.createSettingsBlock(into, extensionsField, SettingsBlock.Full, "Allowed extensions (one per line)");
-        extensionsField.on("input propertychange", function (e) { // Need to update extensions for default val picker
-            save();
-            fileExtensions.splice(0, fileExtensions.length);
-            if (pathTemplate.extensions.length > 0)
-                fileExtensions.push({name: "Allowed extensions", extensions: pathTemplate.extensions});
-        });
+		Fields.createSettingsBlock(into, extensionsField, SettingsBlock.Full, "Allowed extensions (one per line)");
+		extensionsField.on("input propertychange", function (e) { // Need to update extensions for default val picker
+			save();
+			fileExtensions.splice(0, fileExtensions.length);
+			if (pathTemplate.extensions.length > 0)
+				fileExtensions.push({name: "Allowed extensions", extensions: pathTemplate.extensions});
+		});
 	}
 
 	override function save()

--- a/src/rendering/FloatingHTML.hx
+++ b/src/rendering/FloatingHTML.hx
@@ -1,13 +1,8 @@
 package rendering;
 
-import project.data.value.TextValueTemplate;
-import project.data.value.StringValueTemplate;
-import project.data.value.IntegerValueTemplate;
-import project.data.value.FloatValueTemplate;
-import project.data.value.EnumValueTemplate;
-import project.data.value.ColorValueTemplate;
-import project.data.value.BoolValueTemplate;
+import level.data.FilepathData;
 import project.data.ValueDefinition.ValueDisplayType;
+import project.data.value.*;
 import modules.entities.Entity;
 
 class CachedProperty<T>
@@ -176,6 +171,8 @@ class FloatingHTMLPropertyDisplay extends FloatingHTML
                     htmlString += '<p class="value_color" style="background-color: ${val.value};">&nbsp;</p>';
                 else if (val.template.definition.type == EnumValueTemplate)
                     htmlString += '<p>• ${val.value}</p>';
+                else if (val.template.definition.type == FilepathValueTemplate)
+                    htmlString += '<p>[${val.value}]</p>';
                 else if (val.template.definition.type == FloatValueTemplate)
                     htmlString += '<p>${val.value}</p>';
                 else if (val.template.definition.type == IntegerValueTemplate)
@@ -196,6 +193,8 @@ class FloatingHTMLPropertyDisplay extends FloatingHTML
                     htmlString += '<p>${val.template.name} = <span class="value_color" style="background-color: ${val.value}; display: inline-block;">&nbsp;</span></p>';
                 else if (val.template.definition.type == EnumValueTemplate)
                     htmlString += '<p>${val.template.name} = • ${val.value}</p>';
+                else if (val.template.definition.type == FilepathValueTemplate)
+                    htmlString += '<p>${val.template.name} = [${val.value}]</p>';
                 else if (val.template.definition.type == FloatValueTemplate)
                     htmlString += '<p>${val.template.name} = ${val.value}</p>';
                 else if (val.template.definition.type == IntegerValueTemplate)

--- a/src/util/Start.hx
+++ b/src/util/Start.hx
@@ -16,6 +16,7 @@ class Start {
 		BoolValueTemplate.startup();
 		ColorValueTemplate.startup();
 		EnumValueTemplate.startup();
+		FilepathValueTemplate.startup();
 		FloatValueTemplate.startup();
 		IntegerValueTemplate.startup();
 		StringValueTemplate.startup();


### PR DESCRIPTION
For enhancement #120 

Also standardizes all exported paths (normalized + forward-slash) and fixes cancel button behavior for file picker fields.

As template:
![image](https://user-images.githubusercontent.com/3769354/86552669-af552500-bf16-11ea-983e-cfc6a5271f04.png)

Extension filter in file dialog:
![image](https://user-images.githubusercontent.com/3769354/86552945-66ea3700-bf17-11ea-98a8-1c4bfa81938e.png)

As property:
![image](https://user-images.githubusercontent.com/3769354/86552774-f17e6680-bf16-11ea-94d1-fad962badf3d.png)

Toggle between project-relative and level-relative by clicking on the left button. Path adjusts automatically:
![image](https://user-images.githubusercontent.com/3769354/86552854-31dde480-bf17-11ea-82d7-8f2296d9865d.png)

(the directory structure here is:)
![image](https://user-images.githubusercontent.com/3769354/86552816-0f4bcb80-bf17-11ea-9f17-bdb877d64552.png)

Feedback when file extension validation doesn't pass:
![image](https://user-images.githubusercontent.com/3769354/86553083-b92b5800-bf17-11ea-99ec-fd29ca0f9ba9.png)

Multi-selection edit conflict handling (base path and relative path handled as separate conflicts):
![image](https://user-images.githubusercontent.com/3769354/86553159-eed04100-bf17-11ea-83c4-1ebec2f33e6e.png)

![image](https://user-images.githubusercontent.com/3769354/86553197-060f2e80-bf18-11ea-813b-16bd3d2af64d.png)

![image](https://user-images.githubusercontent.com/3769354/86553220-1b845880-bf18-11ea-867d-a706a3cb48ee.png)

The value is exported as a string ex: `proj:tileset.png` or `lvl:../tileset.png`. In the absence of an explicit `proj:` or `lvl:` prefix the path is assumed to be project-relative.