### PR TITLE
Webpack - don't delete bin/settings.json on build

### DIFF
--- a/webpack.app.config.js
+++ b/webpack.app.config.js
@@ -34,7 +34,9 @@ module.exports = (env, argv) => {
         'assets',
         `${__dirname}/package.json` 
       ]),
-      new CleanWebpackPlugin()
+      new CleanWebpackPlugin({
+        cleanOnceBeforeBuildPatterns: ['**/*', '!settings.json']
+      })
     ],
     node: {
       __dirname: false,


### PR DESCRIPTION
After https://github.com/Ogmo-Editor-3/OgmoEditor3-CE/pull/141 settings.json is now in `bin/` directory. But this means it gets deleted on build along with everything else in that directory which is inconvenient (lose recent project history, etc). This PR excludes that specific file from cleanup.

Modified according to:
https://github.com/johnagan/clean-webpack-plugin
https://github.com/johnagan/clean-webpack-plugin/issues/173