### PR TITLE
Smol bugfix: Hover outline now appears for decals

### DIFF
--- a/src/modules/decals/tools/DecalSelectTool.hx
+++ b/src/modules/decals/tools/DecalSelectTool.hx
@@ -281,9 +281,9 @@ class DecalSelectTool extends DecalTool
 		else if (mode == None)
 		{
 			var hit = layer.getAt(pos);
-			var isEqual = true;
+			var isEqual = hit.length == layerEditor.hovered.length;
 			var i = 0;
-			while (isEqual && hit.length == layerEditor.hovered.length && i < hit.length)
+			while (isEqual && i < hit.length)
 			{
 				if (layerEditor.hovered.indexOf(hit[i]) < 0) isEqual = false;
 				i++;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/3769354/87264616-770d9380-c48e-11ea-8680-7b76f317e22d.png)
