### PR TITLE
Entity preview image save bugfix

### DIFF
--- a/src/modules/entities/EntityTemplate.hx
+++ b/src/modules/entities/EntityTemplate.hx
@@ -37,6 +37,7 @@ class EntityTemplate
 	public var values:Array<ValueTemplate> = [];
 	public var tags:Array<String> = [];
 	public var texture:Null<Texture>;
+	public var originalTexturePath:String;
 
 	//Not Exported
 	public var _icon:String = null;
@@ -130,11 +131,13 @@ class EntityTemplate
 		// Try to load the texture from the filepath
 		if (data.texture != null)
 		{
-			 if (FileSystem.exists(data.texture)) e.texture = Texture.fromFile(data.texture);
-			 else if (FileSystem.exists(Path.join(Path.dirname(project.path), data.texture))) e.texture = Texture.fromFile(Path.join(Path.dirname(project.path), data.texture));
+			e.originalTexturePath = data.texture;
+			if (FileSystem.exists(Path.join(Path.dirname(project.path), data.texture)))
+				e.texture = Texture.fromFile(Path.join(Path.dirname(project.path), data.texture));
 		}
 		// If that didnt work, try to load the base64'd version
-		if (e.texture == null && data.textureImage != null) e.texture = Texture.fromString(data.textureImage);
+		if (e.texture == null && data.textureImage != null)
+			e.texture = Texture.fromString(data.textureImage);
 
 		return e;
 	}
@@ -170,7 +173,10 @@ class EntityTemplate
 
 		if (texture != null) 
 		{
-			e.texture = FileSystem.normalize(Path.relative(Path.dirname(OGMO.project.path), texture.path));
+			if (texturePathBroken())
+				e.texture = originalTexturePath;
+			else
+				e.texture = FileSystem.normalize(Path.relative(Path.dirname(OGMO.project.path), texture.path));
 			e.textureImage = texture.image.src;
 		}
 
@@ -188,6 +194,13 @@ class EntityTemplate
 		if (texture != null) return texture.image.src;
 		if (_icon == null) refreshIcon();
 		return _icon;
+	}
+
+	public function texturePathBroken()
+	{
+		if (texture == null)
+			return false;
+		return texture.path == null;
 	}
 
 	public function onShapeChanged()

--- a/src/modules/entities/EntityTemplate.hx
+++ b/src/modules/entities/EntityTemplate.hx
@@ -133,7 +133,9 @@ class EntityTemplate
 		if (data.texture != null)
 		{
 			e.texturePath = data.texture;
-			if (FileSystem.exists(Path.join(Path.dirname(project.path), data.texture)))
+			if (Path.isAbsolute(data.texture) && FileSystem.exists(data.texture))
+				e.setTexture(data.texture, project);
+			else if (FileSystem.exists(Path.join(Path.dirname(project.path), data.texture)))
 				e.setTexture(Path.join(Path.dirname(project.path), data.texture), project);
 		}
 		// If that didnt work, try to load the base64'd version

--- a/src/modules/entities/EntityTemplate.hx
+++ b/src/modules/entities/EntityTemplate.hx
@@ -37,7 +37,7 @@ class EntityTemplate
 	public var values:Array<ValueTemplate> = [];
 	public var tags:Array<String> = [];
 	public var texture:Null<Texture>;
-	public var originalTexturePath:String;
+	public var texturePath:String;
 
 	//Not Exported
 	public var _icon:String = null;
@@ -95,6 +95,7 @@ class EntityTemplate
 		next.nodeGhost = from.nodeGhost;
 		next.tags = from.tags;
 		next.texture = from.texture;
+		next.texturePath = from.texturePath;
 
 		return next;
 	}
@@ -131,9 +132,9 @@ class EntityTemplate
 		// Try to load the texture from the filepath
 		if (data.texture != null)
 		{
-			e.originalTexturePath = data.texture;
+			e.texturePath = data.texture;
 			if (FileSystem.exists(Path.join(Path.dirname(project.path), data.texture)))
-				e.texture = Texture.fromFile(Path.join(Path.dirname(project.path), data.texture));
+				e.setTexture(Path.join(Path.dirname(project.path), data.texture), project);
 		}
 		// If that didnt work, try to load the base64'd version
 		if (e.texture == null && data.textureImage != null)
@@ -173,10 +174,8 @@ class EntityTemplate
 
 		if (texture != null) 
 		{
-			if (texturePathBroken())
-				e.texture = originalTexturePath;
-			else
-				e.texture = FileSystem.normalize(Path.relative(Path.dirname(OGMO.project.path), texture.path));
+			if (texturePath != null)
+				e.texture = texturePath;
 			e.textureImage = texture.image.src;
 		}
 
@@ -196,11 +195,18 @@ class EntityTemplate
 		return _icon;
 	}
 
-	public function texturePathBroken()
+	public function setTexture(absolutePath:String, project:Project)
 	{
-		if (texture == null)
-			return false;
-		return texture.path == null;
+		if (absolutePath == null)
+		{
+			texturePath = null;
+			texture = null;
+		}
+		else
+		{
+			texturePath = FileSystem.normalize(Path.relative(Path.dirname(project.path), absolutePath));
+			texture = Texture.fromFile(absolutePath);
+		}
 	}
 
 	public function onShapeChanged()

--- a/src/modules/entities/ProjectEntitiesPanel.hx
+++ b/src/modules/entities/ProjectEntitiesPanel.hx
@@ -1,12 +1,10 @@
 package modules.entities;
 
-import rendering.Texture;
 import util.RightClickMenu;
 import project.editor.ProjectEditorPanel;
 import util.ItemList;
 import util.Fields;
 import project.editor.ValueTemplateManager;
-import js.node.Path;
 
 class ProjectEntitiesPanel extends ProjectEditorPanel
 {
@@ -496,7 +494,7 @@ class ProjectEntitiesPanel extends ProjectEditorPanel
 						{
 							if (btn == 0)
 							{
-								entity.texture = null;
+								entity.setTexture(null, OGMO.project);
 								texturePreview.empty();
 								refreshList();
 							}
@@ -518,7 +516,7 @@ class ProjectEntitiesPanel extends ProjectEditorPanel
 					var path = FileSystem.chooseFile("Select Preview Image", [{ name: "Images", extensions: ["png", "jpg"] }]);
 					if (FileSystem.exists(path))
 					{
-						entity.texture = Texture.fromFile(path);
+						entity.setTexture(path, OGMO.project);
 
 						texturePreview.empty();
 						var img = new JQuery('<img src="${entity.texture.image.src}"/>');


### PR DESCRIPTION
The bug:
* Project has entity with a preview image
* This image is not on disk (because the user moved/deleted it or the project file has been sent alone to another user)
* Ogmo loads the base64 version stored in the project file, all good so far
* User edits the project
* User saves the project -> Ogmo tries to fetch the texture path but it's null (since loaded from base64) which triggers an exception and the save aborts

Solution:
* Copied the same logic that the tileset image uses: If image is not on disk then export the last used path
* Tested preview image deletion, works ok
* Tested setting a new preview image after loading a broken one, also ok (texture path uses the new texture's path)
* ~~Also removed absolute or executable-relative path support from entity preview image because:~~
    * ~~They get converted to project-relative on save anyway~~
    * ~~For consistency's sake because the tileset image doesn't support them~~
    * ~~The UI generates project-relative paths only, so text-edit was the only way to use those other kinds of paths~~
    * ~~Absolute paths and executable-relative paths will potentially break for other environments/users/OS~~