### PR TITLE
Autotiling Capabilities

### DIFF
--- a/src/modules/tiles/TilePalettePanel.hx
+++ b/src/modules/tiles/TilePalettePanel.hx
@@ -1,5 +1,6 @@
 package modules.tiles;
 
+import js.html.ImageElement;
 import modules.tiles.TileLayer.TileData;
 import js.Browser;
 import js.jquery.Event;
@@ -281,23 +282,33 @@ class TilePalettePanel extends SidePanel
 
 			// draw tiles (+transparent bg)
 			context.fillStyle = "rgb(200,200,200)";
-			var tx = tileset.tileSeparationX + tileset.tileMarginX, x = 0;
-			while(tx < image.width - tileset.tileMarginX)
-			{
-				var ty = tileset.tileSeparationY + tileset.tileMarginY, y = 0;
-				while(ty < image.height - tileset.tileMarginY)
-				{
-					var drawX = x * (tileset.tileWidth + spacing);
-					var drawY = y * (tileset.tileHeight + spacing);
 
-					context.fillRect(drawX - spacing / 2, drawY - spacing / 2, tileset.tileWidth / 2 + spacing / 2, tileset.tileHeight / 2 + spacing / 2);
-					context.fillRect(drawX + tileset.tileWidth / 2, drawY + tileset.tileHeight / 2, tileset.tileWidth / 2 + spacing / 2, tileset.tileHeight / 2 + spacing / 2);
-					context.drawImage(image, tx, ty, tileset.tileWidth, tileset.tileHeight, drawX, drawY, tileset.tileWidth, tileset.tileHeight);
-					ty += tileset.tileHeight + tileset.tileSeparationY;
-					y++;
+			if (tileset.tileAuto)
+			{
+				var tx = tileset.tileSeparationX + tileset.tileMarginX;
+				var ty = tileset.tileSeparationY + tileset.tileMarginY;
+
+				drawTile(image, tx, ty);
+			}
+			else
+			{
+				var tx = tileset.tileSeparationX + tileset.tileMarginX, x = 0;
+				while(tx < image.width - tileset.tileMarginX)
+				{
+					var ty = tileset.tileSeparationY + tileset.tileMarginY, y = 0;
+					while(ty < image.height - tileset.tileMarginY)
+					{
+						var drawX = x * (tileset.tileWidth + spacing);
+						var drawY = y * (tileset.tileHeight + spacing);
+
+						drawTile(image, tx, ty, drawX, drawY);
+
+						ty += tileset.tileHeight + tileset.tileSeparationY;
+						y++;
+					}
+					tx += tileset.tileWidth + tileset.tileSeparationX;
+					x++;
 				}
-				tx += tileset.tileWidth + tileset.tileSeparationX;
-				x++;
 			}
 
 			// get current selection
@@ -320,5 +331,12 @@ class TilePalettePanel extends SidePanel
 				sel.width * (tileset.tileWidth + spacing), sel.height * (tileset.tileHeight + spacing));
 			}
 		}
+	}
+
+	function drawTile(image:ImageElement, tx:Int, ty:Int, drawX:Int = 0, drawY:Int = 0):Void
+	{
+		context.fillRect(drawX - spacing / 2, drawY - spacing / 2, tileset.tileWidth / 2 + spacing / 2, tileset.tileHeight / 2 + spacing / 2);
+		context.fillRect(drawX + tileset.tileWidth / 2, drawY + tileset.tileHeight / 2, tileset.tileWidth / 2 + spacing / 2, tileset.tileHeight / 2 + spacing / 2);
+		context.drawImage(image, tx, ty, tileset.tileWidth, tileset.tileHeight, drawX, drawY, tileset.tileWidth, tileset.tileHeight);
 	}
 }

--- a/src/modules/tiles/TilePalettePanel.hx
+++ b/src/modules/tiles/TilePalettePanel.hx
@@ -32,8 +32,8 @@ class TilePalettePanel extends SidePanel
 	public var rows(get, never):Int;
 
 	function get_tileset():Tileset { return (cast layerEditor.layer : TileLayer).tileset; }
-	function get_columns():Int { return tileset.tileColumns; }
-	function get_rows():Int { return tileset.tileRows; }
+	function get_columns():Int { return tileset.tileAuto ? 1 : tileset.tileColumns; }
+	function get_rows():Int { return tileset.tileAuto ? 1 : tileset.tileRows; }
 
 	public function new(layerEditor: TileLayerEditor)
 	{
@@ -213,6 +213,7 @@ class TilePalettePanel extends SidePanel
 				for (y in 0...selection.height.floor())
 				{
 					var id:Int = selection.x.floor() + x + (selection.y.floor() + y) * columns;
+
 					layerEditor.brush[x].push(new TileData(id));
 				}
 			}

--- a/src/modules/tiles/tools/TilePencilTool.hx
+++ b/src/modules/tiles/tools/TilePencilTool.hx
@@ -12,7 +12,7 @@ class TilePencilTool extends TileTool
 	public var prevPos:Vector = new Vector();
 	public var lastRect:Rectangle = null;
 	public var random:Random = new Random();
-	
+
 	override public function drawOverlay()
 	{
 		if (!drawing)
@@ -113,7 +113,16 @@ class TilePencilTool extends TileTool
 				firstDraw = true;
 			}
 
-			if (OGMO.ctrl)
+			if (layer.tileset.tileAuto)
+			{
+				layer.data[px][py].copy(drawBrush[0][0]);
+
+				for (x in px-1...px+2)
+					for (y in py-1...py+2)
+						if (layer.data[x][y].idx > -1)
+							layer.data[x][y].idx = layer.tileset.autotile.getTileId(x, y, layer.data);
+			}
+			else if (OGMO.ctrl)
 			{
 				if (layer.insideGrid(pos))
 				{

--- a/src/project/data/Tileset.hx
+++ b/src/project/data/Tileset.hx
@@ -98,7 +98,7 @@ class Tileset
 
 	inline function get_height():Int return texture.image.height;
 
-	inline function get_tileColumns():Int return Math.floor((width - tileSeparationX - tileMarginX - tileMarginX) / (tileWidth + tileSeparationX));
+	inline function get_tileColumns():Int return tileAuto ? 1 : Math.floor((width - tileSeparationX - tileMarginX - tileMarginX) / (tileWidth + tileSeparationX));
 
-	inline function get_tileRows():Int return Math.floor((height - tileSeparationY - tileMarginY - tileMarginY) / (tileHeight + tileSeparationY));
+	inline function get_tileRows():Int return tileAuto ? 1 : Math.floor((height - tileSeparationY - tileMarginY - tileMarginY) / (tileHeight + tileSeparationY));
 }

--- a/src/project/data/Tileset.hx
+++ b/src/project/data/Tileset.hx
@@ -98,7 +98,7 @@ class Tileset
 
 	inline function get_height():Int return texture.image.height;
 
-	inline function get_tileColumns():Int return tileAuto ? 1 : Math.floor((width - tileSeparationX - tileMarginX - tileMarginX) / (tileWidth + tileSeparationX));
+	inline function get_tileColumns():Int return Math.floor((width - tileSeparationX - tileMarginX - tileMarginX) / (tileWidth + tileSeparationX));
 
-	inline function get_tileRows():Int return tileAuto ? 1 : Math.floor((height - tileSeparationY - tileMarginY - tileMarginY) / (tileHeight + tileSeparationY));
+	inline function get_tileRows():Int return Math.floor((height - tileSeparationY - tileMarginY - tileMarginY) / (tileHeight + tileSeparationY));
 }

--- a/src/project/data/Tileset.hx
+++ b/src/project/data/Tileset.hx
@@ -1,5 +1,6 @@
 package project.data;
 
+import modules.tiles.TileLayer.TileData;
 import io.FileSystem;
 import js.Browser;
 import js.node.Path;
@@ -24,6 +25,8 @@ class Tileset
 	public var tileSeparationY: Int;
 	public var tileMarginX: Int;
 	public var tileMarginY: Int;
+
+	public var autotile: Autotile;
 
 	public var brokenPath:Bool = false;
 	public var brokenTexture:Bool = false;
@@ -54,6 +57,11 @@ class Tileset
 			brokenPath = true;
 			brokenTexture = true;
 			texture = Texture.fromString("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAsklEQVRYhcVXQQ6AIAwrPmlv8Zm8xS/NgyERAgpj0CUkJtK14mAlAFAQ4wCAKLKd+M2pADSKaHpePQqu5osd5LmA1SIaubsnriCvC/AW8ZPLDPQg/xYwK6IT65bIinFPOCrY96sMq+W3tMZ6GQZUiSaK1QTKCGd2SkgqLJE62nld1hRPO2YH9ReYBFCLkLoNqQcR9SimNiNqO6YaEqolo5pSqi2nXkyoV7Od5KWIKT/gETfAGp5SxRHyngAAAABJRU5ErkJggg==");
+		}
+
+		if (tileAuto)
+		{
+			autotile = new Autotile();
 		}
 	}
 
@@ -101,4 +109,54 @@ class Tileset
 	inline function get_tileColumns():Int return Math.floor((width - tileSeparationX - tileMarginX - tileMarginX) / (tileWidth + tileSeparationX));
 
 	inline function get_tileRows():Int return Math.floor((height - tileSeparationY - tileMarginY - tileMarginY) / (tileHeight + tileSeparationY));
+}
+
+class Autotile
+{
+	public static final X0_Y0: Int = 1 << 0;
+	public static final X1_Y0: Int = 1 << 1;
+	public static final X2_Y0: Int = 1 << 2;
+	public static final X0_Y1: Int = 1 << 3;
+	public static final X2_Y1: Int = 1 << 4;
+	public static final X0_Y2: Int = 1 << 5;
+	public static final X1_Y2: Int = 1 << 6;
+	public static final X2_Y2: Int = 1 << 7;
+
+	private var autotileMapping: Map<Int, Int> = [];
+
+	public function new()
+	{
+		var tile = 0;
+		for (i in 0...256)
+		{
+			if (!(
+				((~i & X1_Y0) != 0 && ((i & X0_Y0) != 0 || (i & X2_Y0) != 0)) ||
+				((~i & X0_Y1) != 0 && ((i & X0_Y0) != 0 || (i & X0_Y2) != 0)) ||
+				((~i & X2_Y1) != 0 && ((i & X2_Y0) != 0 || (i & X2_Y2) != 0)) ||
+				((~i & X1_Y2) != 0 && ((i & X0_Y2) != 0 || (i & X2_Y2) != 0))
+			))
+			{
+				autotileMapping[i] = tile++;
+			}
+		}
+	}
+
+	public function getTileId(x:Int, y:Int, data:Array<Array<TileData>>):Int
+	{
+		final is = (x, y) -> data[x][y].idx != -1;
+
+		var mask = 0;
+
+		if (is(x, y + 1)) mask += X1_Y2;
+		if (is(x, y - 1)) mask += X1_Y0;
+		if (is(x - 1, y)) mask += X0_Y1;
+		if (is(x + 1, y)) mask += X2_Y1;
+
+		if ((mask & (X1_Y2 | X0_Y1)) == (X1_Y2 | X0_Y1) && is(x - 1, y + 1)) mask += X0_Y2;
+		if ((mask & (X1_Y2 | X2_Y1)) == (X1_Y2 | X2_Y1) && is(x + 1, y + 1)) mask += X2_Y2;
+		if ((mask & (X1_Y0 | X0_Y1)) == (X1_Y0 | X0_Y1) && is(x - 1, y - 1)) mask += X0_Y0;
+		if ((mask & (X1_Y0 | X2_Y1)) == (X1_Y0 | X2_Y1) && is(x + 1, y - 1)) mask += X2_Y0;
+
+		return autotileMapping[mask];
+	}
 }

--- a/src/project/data/Tileset.hx
+++ b/src/project/data/Tileset.hx
@@ -17,6 +17,7 @@ class Tileset
 
 	public var tileColumns(get, null):Int;
 	public var tileRows(get, null):Int;
+	public var tileAuto: Bool;
 	public var tileWidth: Int;
 	public var tileHeight: Int;
 	public var tileSeparationX: Int;
@@ -27,10 +28,11 @@ class Tileset
 	public var brokenPath:Bool = false;
 	public var brokenTexture:Bool = false;
 
-	public function new(project:Project, label:String, path:String, tileWidth:Int, tileHeight:Int, tileSepX:Int, tileSepY:Int, tileMargX:Int, tileMargY:Int, ?image:ImageElement)
+	public function new(project:Project, label:String, path:String, tileAuto:Bool, tileWidth:Int, tileHeight:Int, tileSepX:Int, tileSepY:Int, tileMargX:Int, tileMargY:Int, ?image:ImageElement)
 	{
 		this.label = label;
 		this.path = haxe.io.Path.normalize(path);
+		this.tileAuto = tileAuto;
 		this.tileWidth = tileWidth;
 		this.tileHeight = tileHeight;
 		this.tileSeparationX = tileSepX;
@@ -61,6 +63,7 @@ class Tileset
 		data.label = label;
 		data.path = path;
 		data.image = texture.image.src;
+		data.tileAuto = tileAuto;
 		data.tileWidth = tileWidth;
 		data.tileHeight = tileHeight;
 		data.tileSeparationX = tileSeparationX;
@@ -82,7 +85,7 @@ class Tileset
 		if (Reflect.hasField(data, "tileMarginY"))
 			marginY = data.tileMarginY;
 
-		return new Tileset(project, data.label, data.path, data.tileWidth, data.tileHeight, data.tileSeparationX, data.tileSeparationY, marginX, marginY, img);
+		return new Tileset(project, data.label, data.path, data.tileAuto, data.tileWidth, data.tileHeight, data.tileSeparationX, data.tileSeparationY, marginX, marginY, img);
 	}
 
 	public inline function getTileX(id: Int):Int return id % tileColumns;


### PR DESCRIPTION
# AutoTile

The feature every cool kid is talking about.

## Acknowledgement
Ok, so, I'm aware of the #59 and the `autotiling` branch by @01010111 
But I was really confused by how that works, specially the "*Reference Map*" thing.
Besides, the branch seems inactive (89 commits behind master, initial work was in December '19 with only minor update in June '20).

So I figured I'd take my shot and implement a simplified version of my [Tegulas](https://github.com/NemoStein/tegulas) AutoTile.

## How to use it?
- Create a new **Tileset**
- Use a tileset that has its tiles arranged according to the template (I'll talk more about it latter)
- Configure your tileset as you usually do (name, tile size, separation etc)
- Check the `Auto Tiling` checkbox
- Confirm (visually) that only the 1st tile of the tileset is highlighted
- In a **Tile Layer** with this tileset selected, draw with the only tile available in the palette

The layer will update itself to select the correct tile to be placed.

## What about this "template"?
The template is a tileset of  8 columns by 6 rows, containing each and every possible combination of its tiles.
It's something like this:
![image](https://user-images.githubusercontent.com/2738812/95805563-159ed000-0cdc-11eb-8ddc-7317138f5b44.png)

This is confusing, I know!!
I was planning to implement one of the coolest thing (IMHO) of the original tool that is generating the complete tileset based on a simpler (5 tiles) version of it, like this:
![image](https://user-images.githubusercontent.com/2738812/95805726-70d0c280-0cdc-11eb-8710-5e0d11c5c803.png)

It works by slicing each tile into 4 and mixing and matching them to generate the full tileset.
Of course, using the full tileset gives you a lot of freedom to draw each individual tile, but the simple version is extremely easy to draw and use.

Also, this could be easily implemented exchanging the checkbox for a dropdown select (e.g.: `Auto Tiling = none, simple, full`).
I'm just not sure if this kind of automation fits Ogmo or if its better to have this as a external tool that generates the tileset for you ahead-of-time.

## What is missing?
Ok, for now only the `Pencil` tool is supported.
Holding ctrl doesn't change the tool behavior, but I was planning to use it to temporarily disable the automatic update of the tiles around the one you are painting, but I don't know if this could have a use case.
The implementation of other tools is planned in case this PR attracts interest and gains traction.

## Final considerations
I've tried my best to keep the coding standard and style of my code aligned with the rest of the codebase.
If desirable, the maintainers/reviewers can update or request updates at will and I'm willing to keep giving support for this tool.