### PR TITLE
Add current level path to the play command as an argument.

### DIFF
--- a/src/level/editor/Editor.hx
+++ b/src/level/editor/Editor.hx
@@ -262,7 +262,7 @@ class Editor
 				if (executingPlayCommand == null)
 				{
 					js.Lib.require('fix-path')();
-					executingPlayCommand = ChildProcess.spawn(OGMO.project.playCommand, {
+					executingPlayCommand = ChildProcess.spawn(OGMO.project.playCommand + ' ' + EDITOR.level.path, {
 						cwd: Path.directory(OGMO.project.path),
 						shell: true
 					});


### PR DESCRIPTION
# Run Current Level

this pr addresses #166 with a single line change. It adds the current level path as a command line argument to the play command, which can allow the game to load directly to the given level. This speeds up the level creation cycle as your game could skip all of the menus and other levels, and play directly this one.

If the play command is `/path/to/game --load-level`, what is actually run is `/path/to/game --load-level /path/to/ogmo/level.json`.

## Potential Issues
- Breaking existing projects if the game does not expect a command line argument.
- Level file names with spaces may not work.
- I noticed the level does not save on run, that would be something else to maybe add.
