### PR TITLE
Open project when app is launched with project file

### DIFF
--- a/src/Ogmo.hx
+++ b/src/Ogmo.hx
@@ -138,12 +138,20 @@ class Ogmo
 					Controls.setupJQuery();
 			}
 		});
-
+		
 		// Run startup functions
 		Start.up();
 		//Init the toolbelt
 		editor.toolBelt = new ToolBelt();
 		updateWindowTitle();
+
+		// Setup handler for 'openFile' event.
+		IpcRenderer.on("openFile", function (event, path: String) {
+			if (startPage.active && FileSystem.exists(path)) {
+				startPage.onOpenProject(path);
+			}
+		});
+		IpcRenderer.send("readyForFileEvents");
 	}
 
 	public function loop(?dt:Float):Void

--- a/src/StartPage.hx
+++ b/src/StartPage.hx
@@ -29,8 +29,6 @@ class StartPage
 			var path = FileSystem.chooseFile("Select Project", [{ name: "Ogmo Editor Project", extensions: ["ogmo"]}]);
 			if (FileSystem.exists(path)) onOpenProject(path);
 		});
-
-		tryOpenLaunchFile();
 	}
 
 	public function onNewProject(path:String):Void
@@ -75,15 +73,4 @@ class StartPage
 	public function keyRepeat(key:Int):Void {}
 
 	public function keyRelease(key:Int):Void {}
-
-	// Check if the app was launched with an associated file.
-	private function tryOpenLaunchFile(): Void {
-		IpcRenderer
-			.invoke("getLaunchFilePath")
-			.then((path) -> {
-				if (path != null && FileSystem.exists(path)) {
-					onOpenProject(path);
-				}
-			});
-	}
 }

--- a/src/StartPage.hx
+++ b/src/StartPage.hx
@@ -2,7 +2,7 @@ import io.Imports;
 import io.FileSystem;
 import project.data.Project;
 import js.jquery.JQuery;
-import electron.renderer.Remote;
+import electron.renderer.IpcRenderer;
 
 class StartPage
 {
@@ -29,6 +29,8 @@ class StartPage
 			var path = FileSystem.chooseFile("Select Project", [{ name: "Ogmo Editor Project", extensions: ["ogmo"]}]);
 			if (FileSystem.exists(path)) onOpenProject(path);
 		});
+
+		tryOpenLaunchFile();
 	}
 
 	public function onNewProject(path:String):Void
@@ -73,4 +75,15 @@ class StartPage
 	public function keyRepeat(key:Int):Void {}
 
 	public function keyRelease(key:Int):Void {}
+
+	// Check if the app was launched with an associated file.
+	private function tryOpenLaunchFile(): Void {
+		IpcRenderer
+			.invoke("getLaunchFilePath")
+			.then((path) -> {
+				if (path != null && FileSystem.exists(path)) {
+					onOpenProject(path);
+				}
+			});
+	}
 }


### PR DESCRIPTION
Issue: #44 

Handle opening project files when the app is launched via file association.

Can someone test this on Windows? 

Also, on Windows and Linux this should allow you to open projects from the command-line by passing a project file as the first argument.