### PR TITLE
Enhancement: Support tabbing between inputs, relinquish focus on fields with Enter, don't lose focus on fields when an entity or decal is hovered

### DIFF
--- a/src/Ogmo.hx
+++ b/src/Ogmo.hx
@@ -98,7 +98,7 @@ class Ogmo
 				case Keys.Y:
 					if (ogmo.ctrl) e.preventDefault();
 				case Keys.Tab:
-					if (popupMode || editor.active) e.preventDefault();
+					if (popupMode) e.preventDefault();
 			}
 		});
 

--- a/src/assets/styles/input.scss
+++ b/src/assets/styles/input.scss
@@ -29,6 +29,12 @@ input, select, textarea
 	border-radius: 2px;
 }
 select { height: 36px; max-width: 200px; font-size: 0.9em; }
+select:focus
+{
+    font-weight: bold;
+    color: #000;
+    border: 1px solid #000;
+}
 input[type="color"]::-webkit-color-swatch-wrapper { padding: 0; }
 input[type="color"]::-webkit-color-swatch { border: none; }
 input.default-value { color: #888; }
@@ -134,14 +140,14 @@ textarea, input, button, select { font-family: inherit; }
         border-bottom-right-radius: 0;
     }
 
-    &:hover
+    &:hover, &:focus
     {
         font-weight: bold;
         color: #000;
         border: 1px solid #000;
     }
-    &:hover &_icon { }
-    &:hover &_icon::after { background-color: #000; }
+    &:hover &_icon, &:focus &_icon { }
+    &:hover &_icon::after, &:focus &_icon::after { background-color: #000; }
 
     &.important
     {

--- a/src/level/editor/ui/LevelsPanel.hx
+++ b/src/level/editor/ui/LevelsPanel.hx
@@ -48,7 +48,7 @@ class LevelsPanel extends SidePanel
 		options.append(newbutton);
 
 		// search bar
-		searchbar = new JQuery('<div class="searchbar"><div class="searchbar_icon icon icon-magnify-glass"></div><input class="searchbar_field"/></div>');
+		searchbar = new JQuery('<div class="searchbar"><div class="searchbar_icon icon icon-magnify-glass"></div><input class="searchbar_field" tabindex="-1"/></div>');
 		searchbar.find("input").on("change keyup", refresh);
 		options.append(searchbar);
 

--- a/src/level/editor/ui/StickerDropdown.hx
+++ b/src/level/editor/ui/StickerDropdown.hx
@@ -78,7 +78,7 @@ class StickerDropdown
 
     public function addSlider(label:String, min:Int = 0, max:Int = 100, value:Int = 50, onChange:Int->Void, ?tooltip:String)
     {
-        var listElement = new JQuery('<div class="sticker-dropdown-item slider"><input type="range" min="$min" max="$max" value="$value" class="slider"><div class="label">${label}:&nbsp</div><div class="value">${toPercentDisplayText(value)}</div></div>');
+        var listElement = new JQuery('<div class="sticker-dropdown-item slider"><input type="range" min="$min" max="$max" value="$value" class="slider" tabindex="-1"><div class="label">${label}:&nbsp</div><div class="value">${toPercentDisplayText(value)}</div></div>');
         var sliderElement = listElement.find(".slider");
         var valueElement = listElement.find(".value");
         sliderElement.on("input", function (e)

--- a/src/modules/decals/DecalLayer.hx
+++ b/src/modules/decals/DecalLayer.hx
@@ -38,8 +38,6 @@ class DecalLayer extends Layer
 
 			var values = Imports.values(decal, (cast template:DecalLayerTemplate).values);
 
-			trace(path + ", " + relative);
-
 			for (tex in (cast template : DecalLayerTemplate).textures)
 				if (tex.path == relative)
 				{

--- a/src/modules/decals/tools/DecalSelectTool.hx
+++ b/src/modules/decals/tools/DecalSelectTool.hx
@@ -292,7 +292,6 @@ class DecalSelectTool extends DecalTool
 			if (!isEqual)
 			{
 				layerEditor.hovered = hit;
-				layerEditor.selectedChanged = true;
 				EDITOR.dirty();
 			}
 		}

--- a/src/modules/entities/EntityPalettePanel.hx
+++ b/src/modules/entities/EntityPalettePanel.hx
@@ -27,7 +27,7 @@ class EntityPalettePanel extends SidePanel
 	{
 		var self = this;
 
-		searchbar = new JQuery('<div class="searchbar"><div class="searchbar_icon icon icon-magnify-glass"></div><input class="searchbar_field"/></div>');
+		searchbar = new JQuery('<div class="searchbar"><div class="searchbar_icon icon icon-magnify-glass"></div><input class="searchbar_field" tabindex="-1"/></div>');
 		searchbar.find("input").on("change keyup", function() { self.refresh(); });
 		palette = new JQuery('<div class="entityPalette">');
 

--- a/src/modules/entities/ProjectEntitiesPanel.hx
+++ b/src/modules/entities/ProjectEntitiesPanel.hx
@@ -75,7 +75,7 @@ class ProjectEntitiesPanel extends ProjectEditorPanel
 			entitiesList = new JQuery('<div class="list">');
 			entities.append(entitiesList);
 
-			searchbar = new JQuery('<div class="searchbar"><div class="searchbar_icon icon icon-magnify-glass"></div><input class="searchbar_field"/></div>');
+			searchbar = new JQuery('<div class="searchbar"><div class="searchbar_icon icon icon-magnify-glass"></div><input class="searchbar_field" tabindex="-1"/></div>');
 			searchbar.find("input").on("change keyup", function() { refreshList(); });
 			palette = new JQuery('<div class="entityList">');
 

--- a/src/modules/entities/tools/EntitySelectTool.hx
+++ b/src/modules/entities/tools/EntitySelectTool.hx
@@ -110,7 +110,6 @@ class EntitySelectTool extends EntityTool
 			if (!layerEditor.hovered.equals(hit))
 			{
 				layerEditor.hovered.set(hit);
-				layerEditor.selection.changed = true;
 				EDITOR.dirty();
 			}
 		}

--- a/src/util/Fields.hx
+++ b/src/util/Fields.hx
@@ -35,7 +35,12 @@ class Fields
 			element.addClass("default-value");
 			element.val(label);
 		}
-		
+
+		element.on("keyup", function(e)
+		{
+			if (e.keyCode == Keys.Enter)
+				element.blur();
+		});
 		element.on("focus", function(e)
 		{
 			if (element.hasClass("default-value"))

--- a/src/util/Fields.hx
+++ b/src/util/Fields.hx
@@ -154,7 +154,7 @@ class Fields
 
 	public static function createButton(icon:String, label:String, ?into:JQuery):JQuery
 	{
-		var element = new JQuery('<div>');
+		var element = new JQuery('<button>');
 		element.addClass("button");
 
 		if (icon != null && icon.length > 0)


### PR DESCRIPTION
OK. My apologies for including a bit too much in this PR. My excuse is that it is all vaguely related to field data entry.

1. Changing field values in Ogmo is kind of a hassle right now. This change allows you to select an entity or decal or whatever, and use tab to navigate the field values.

2. An existing UX issue is that you cannot save your level when you have a field focused, so you have to click somewhere on the screen to blur the field before saving. I addressed this by having the enter key blur the field, like Blender. But maybe the need to blur the field before being able to save is not intended behavior in the first place--in which case it should probably be addressed in a different way.

3. I also fixed an issue where your field inputs would be recreated, and thus lose focus, when you hovered over another entity or decal on the layer. This seemed like a bug to me, although it was pasted into both of the SelectTool classes.

4. I removed some console spam because it didn't seem particularly useful.

Here's a cool video demoing some of this:

https://user-images.githubusercontent.com/25911974/146605328-2b9b582a-329d-49e7-850f-35e674067d5e.mp4