### PR TITLE
Change default lastPaletteHeight to a larger number than 0.

### DIFF
--- a/src/level/editor/Editor.hx
+++ b/src/level/editor/Editor.hx
@@ -57,7 +57,7 @@ class Editor
 	var resizingRight:Bool = false;
 	var resizingLayers:Bool = false;
 	var resizingPalette:Bool = false;
-	var lastPaletteHeight:Float = 0;
+	var lastPaletteHeight:Float = 500;
 	var state:Null<EditorState>;
 
 	var executingPlayCommand:Null<ChildProcessObject>;


### PR DESCRIPTION
This is for that case where you click "Edit Project", do some stuff, then click "Save & Update", and you can't "see" the entity/decal palette anymore. From my experimenting, I think it turns out that `lastPaletteHeight` was setting the editor palette height to 0.

This doesn't root-cause the issue as to why `lastPaletteHeight` remains 0 on refresh, but it does fix the entity panel becoming hidden when you save and update your project.